### PR TITLE
Feature/multiplier property tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -410,6 +410,33 @@ mod property_tests {
             // Every valid streak must yield a multiplier above 1x (10_000 bps)
             prop_assert!(get_multiplier(streak) > 10_000);
         }
+
+        /// Invariant: multiplier never exceeds the 10x cap (100_000 bps) for any input.
+        #[test]
+        fn test_multiplier_never_exceeds_cap(streak in 0u32..=u32::MAX) {
+            prop_assert!(get_multiplier(streak) <= 100_000);
+        }
+
+        /// Invariant: streaks 1–3 each map to their exact documented constant.
+        /// Catches any accidental reordering or off-by-one in the match arms.
+        #[test]
+        fn test_multiplier_exact_values_streaks_1_to_3(streak in 1u32..=3u32) {
+            let expected = match streak {
+                1 => 19_000,
+                2 => 35_000,
+                3 => 60_000,
+                _ => unreachable!(),
+            };
+            prop_assert_eq!(get_multiplier(streak), expected);
+        }
+
+        /// Invariant: the cap boundary is exactly at streak 4 — streak 3 must be
+        /// strictly below the cap and streak 4 must equal it.
+        #[test]
+        fn test_multiplier_cap_boundary(streak in 4u32..=1_000u32) {
+            prop_assert!(get_multiplier(3) < get_multiplier(streak));
+            prop_assert_eq!(get_multiplier(streak), get_multiplier(4));
+        }
     }
 
     // Feature: soroban-coinflip-game, Property: distinct addresses always accepted


### PR DESCRIPTION
Closes #98


## What changed

Added 3 new property tests (100 iterations each):

- test_multiplier_exact_values_streaks_1_to_3 — verifies each streak 1–3 returns its exact constant (19_000 / 35_000 / 
60_000), catching any match arm reordering
- test_multiplier_never_exceeds_cap — asserts get_multiplier(n) <= 100_000 for all u32 inputs, ensuring no payout can 
exceed 10x
- test_multiplier_cap_boundary — confirms the cap activates at exactly streak 4; streak 3 is strictly below it

## Test output

test property_tests::test_multiplier_cap_boundary ... ok
test property_tests::test_multiplier_exact_values_streaks_1_to_3 ... ok
test property_tests::test_multiplier_never_exceeds_cap ... ok
test property_tests::test_multiplier_always_greater_than_1x ... ok
test property_tests::test_multiplier_monotonically_increasing ... ok
test property_tests::test_multiplier_streak_4_plus_is_constant ... ok

test result: ok. 20 passed; 0 failed; 0 ignored


## Notes

All pre-existing multiplier properties are retained. The 3 new tests close the gaps around exact value correctness, the
hard 10x upper bound, and the precise streak 3→4 boundary.
