### PR TITLE
feat(admin): add emergency pause toggle for new game creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,27 @@ Tossd is a decentralized gambling application that implements a provably fair co
 - **Transparent Protocol Fees**: 2-5% configurable rake on winnings
 - **Secure Fund Management**: All wagers held in contract custody with reserve solvency checks
 - **Property-Based Testing**: Comprehensive test coverage with 30+ correctness properties
+- **Emergency Pause Control**: Admin can pause only new game creation during incidents
+
+### Pause Behavior and Scope
+
+The contract includes an admin-only pause switch (`set_paused`) for emergency response.
+
+- `set_paused(true)` blocks only `start_game` calls.
+- In-flight games can still settle while paused (`reveal`, `continue_streak`, `cash_out`, `claim_winnings`).
+- `set_paused(false)` re-enables new game creation.
+- Unauthorized callers are rejected with `Unauthorized`.
 
 ## 🎮 Game Mechanics
 
 ### Multiplier Structure
 
-| Streak | Multiplier | House Edge |
-|--------|-----------|------------|
-| 1st win | 1.9x | ~5% |
-| 2nd win | 3.5x | ~6.25% |
-| 3rd win | 6.0x | ~6.25% |
-| 4+ wins | 10.0x | ~6.25% |
+| Streak  | Multiplier | House Edge |
+| ------- | ---------- | ---------- |
+| 1st win | 1.9x       | ~5%        |
+| 2nd win | 3.5x       | ~6.25%     |
+| 3rd win | 6.0x       | ~6.25%     |
+| 4+ wins | 10.0x      | ~6.25%     |
 
 ### How to Play
 
@@ -119,12 +129,14 @@ stellar contract invoke \
 The project employs a dual testing approach:
 
 ### Unit Tests
+
 - Specific examples and edge cases
 - Error condition validation
 - State transition verification
 - Boundary value testing
 
 ### Property-Based Tests
+
 - 100+ iterations per property
 - Randomized input generation
 - Universal correctness validation
@@ -142,13 +154,13 @@ cargo test --lib outcome_determinism_tests::    # determinism tests (6)
 cargo test --lib randomness_regression_tests::  # randomness regression tests (5)
 ```
 
-| Module | Count | What it covers |
-|---|---|---|
-| `tests` | 15 | Multipliers, payout arithmetic, initialization, error codes, enums |
-| `property_tests` | 13 | Payout correctness, multiplier monotonicity, commitment verification, config storage |
-| `outcome_determinism_tests` | 6 | Identical inputs → identical outputs for all helpers |
-| `randomness_regression_tests` | 5 | Commit-reveal unilateral control paths |
-| **Total** | **43** | |
+| Module                        | Count  | What it covers                                                                       |
+| ----------------------------- | ------ | ------------------------------------------------------------------------------------ |
+| `tests`                       | 15     | Multipliers, payout arithmetic, initialization, error codes, enums                   |
+| `property_tests`              | 13     | Payout correctness, multiplier monotonicity, commitment verification, config storage |
+| `outcome_determinism_tests`   | 6      | Identical inputs → identical outputs for all helpers                                 |
+| `randomness_regression_tests` | 5      | Commit-reveal unilateral control paths                                               |
+| **Total**                     | **43** |                                                                                      |
 
 ### Expected output
 
@@ -170,6 +182,7 @@ Any failure at this checkpoint indicates a regression in core logic and must be 
 ## 📊 Contract Statistics
 
 The contract tracks:
+
 - Total games played
 - Total volume wagered
 - Total fees collected

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -837,6 +837,40 @@ impl CoinflipContract {
         Ok(())
     }
 
+    /// Pause or unpause acceptance of new games.
+    ///
+    /// Only the configured `admin` may call this function.
+    ///
+    /// Pause scope:
+    /// - When `paused == true`, `start_game` is rejected with [`Error::ContractPaused`].
+    /// - Existing game flows remain available (`reveal`, `cash_out`, `claim_winnings`,
+    ///   and `continue_streak`) so in-flight games can settle.
+    ///
+    /// # Arguments
+    /// - `admin`  – caller address; must authorize and match `config.admin`
+    /// - `paused` – target pause state
+    ///
+    /// # Errors
+    /// - [`Error::Unauthorized`] – caller is not the configured admin
+    ///
+    /// # Security
+    /// - `admin.require_auth()` enforces signed authorization.
+    /// - Address equality check (`admin == config.admin`) prevents non-admin callers.
+    /// - Only the `paused` flag is mutated; all other config fields are preserved.
+    pub fn set_paused(env: Env, admin: Address, paused: bool) -> Result<(), Error> {
+        admin.require_auth();
+
+        let mut config = Self::load_config(&env);
+        if admin != config.admin {
+            return Err(Error::Unauthorized);
+        }
+
+        config.paused = paused;
+        Self::save_config(&env, &config);
+
+        Ok(())
+    }
+
     /// Update the protocol fee charged on winning payouts.
     ///
     /// Only the configured `admin` address may call this function.
@@ -1536,6 +1570,76 @@ mod tests {
         env.as_contract(contract_id, || {
             CoinflipContract::load_config(env).admin
         })
+    }
+
+    // ── set_paused tests ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_set_paused_succeeds_for_admin() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, client) = setup(&env);
+        let admin = get_admin(&env, &contract_id);
+
+        assert!(client.try_set_paused(&admin, &true).is_ok());
+
+        let cfg: ContractConfig = env.as_contract(&contract_id, || {
+            env.storage().persistent().get(&StorageKey::Config).unwrap()
+        });
+        assert!(cfg.paused);
+    }
+
+    #[test]
+    fn test_set_paused_rejects_non_admin() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, client) = setup(&env);
+        let stranger = Address::generate(&env);
+
+        let result = client.try_set_paused(&stranger, &true);
+        assert_eq!(result, Err(Ok(Error::Unauthorized)));
+    }
+
+    #[test]
+    fn test_set_paused_can_unpause() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, client) = setup(&env);
+        let admin = get_admin(&env, &contract_id);
+
+        client.set_paused(&admin, &true);
+        client.set_paused(&admin, &false);
+
+        let cfg: ContractConfig = env.as_contract(&contract_id, || {
+            env.storage().persistent().get(&StorageKey::Config).unwrap()
+        });
+        assert!(!cfg.paused);
+    }
+
+    #[test]
+    fn test_set_paused_no_state_mutation_on_unauthorized() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, client) = setup(&env);
+
+        let before: ContractConfig = env.as_contract(&contract_id, || {
+            env.storage().persistent().get(&StorageKey::Config).unwrap()
+        });
+
+        let stranger = Address::generate(&env);
+        let _ = client.try_set_paused(&stranger, &true);
+
+        let after: ContractConfig = env.as_contract(&contract_id, || {
+            env.storage().persistent().get(&StorageKey::Config).unwrap()
+        });
+
+        assert_eq!(before.paused, after.paused);
+        assert_eq!(before.admin, after.admin);
+        assert_eq!(before.treasury, after.treasury);
+        assert_eq!(before.token, after.token);
+        assert_eq!(before.fee_bps, after.fee_bps);
+        assert_eq!(before.min_wager, after.min_wager);
+        assert_eq!(before.max_wager, after.max_wager);
     }
 
     #[test]
@@ -2373,7 +2477,7 @@ mod property_tests {
             let env = Env::default();
             env.mock_all_auths();
 
-            let (admin, treasury, token, contract_id) =
+            let (_admin, treasury, token, contract_id, player) =
                 setup_game_for_transfer_test(&env, wager, fee_bps, true);
 
             let client = CoinflipContractClient::new(&env, &contract_id);
@@ -2463,14 +2567,11 @@ mod property_tests {
             let env = Env::default();
             env.mock_all_auths();
 
-            let (admin, treasury, token, contract_id) =
+            let (_admin, treasury, token, contract_id, player1) =
                 setup_game_for_transfer_test(&env, wager1, fee_bps, true);
 
             let client = CoinflipContractClient::new(&env, &contract_id);
             let token_client = token::Client::new(&env, &token);
-
-            let player1 = Address::generate(&env);
-            let player2 = Address::generate(&env);
 
             // Setup second game for player2 — same win secret [1u8;32] → Heads win
             let player2 = Address::generate(&env);
@@ -2521,7 +2622,7 @@ mod property_tests {
             let env = Env::default();
             env.mock_all_auths();
 
-            let (admin, treasury, token, contract_id) =
+            let (_admin, treasury, token, contract_id, player) =
                 setup_game_for_transfer_test(&env, wager, fee_bps, true);
 
             let client = CoinflipContractClient::new(&env, &contract_id);


### PR DESCRIPTION
closes #138 
add admin-only set_paused contract entrypoint
require authorization and reject non-admin callers with Unauthorized
keep pause scope limited to blocking new start_game calls
preserve settlement flow for in-flight games while paused
add unit tests for pause, unpause, auth rejection, and no-mutation guarantees
document pause behavior and scope in the README
