### PR TITLE
fix: consistent error codes across all public entrypoints

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -46,15 +46,15 @@ use soroban_sdk::{contract, contractimpl, contracttype, contracterror, token, Ad
 /// | 3    | `ActiveGameExists`           | Game creation  | `start_game`                       |
 /// | 4    | `InsufficientReserves`       | Game creation  | `start_game`, `continue_streak`    |
 /// | 5    | `ContractPaused`             | Game creation  | `start_game`                       |
-/// | 10   | `NoActiveGame`               | Game state     | `reveal`, `claim_winnings`, `continue_streak` |
-/// | 11   | `InvalidPhase`               | Game state     | `reveal`, `claim_winnings`, `continue_streak` |
+/// | 10   | `NoActiveGame`               | Game state     | `reveal`, `claim_winnings`, `continue_streak`, `cash_out` |
+/// | 11   | `InvalidPhase`               | Game state     | `reveal`, `claim_winnings`, `continue_streak`, `cash_out` |
 /// | 12   | `CommitmentMismatch`         | Reveal         | `reveal`                           |
-/// | 13   | `RevealTimeout`              | Reveal         | (reserved)                         |
-/// | 20   | `NoWinningsToClaimOrContinue`| Action         | `continue_streak`                  |
+/// | 13   | `RevealTimeout`              | Reveal         | (reserved for future timeout enforcement) |
+/// | 20   | `NoWinningsToClaimOrContinue`| Action         | `cash_out`, `claim_winnings`, `continue_streak` |
 /// | 21   | `InvalidCommitment`          | Action         | `continue_streak`                  |
-/// | 30   | `Unauthorized`               | Admin          | (reserved)                         |
-/// | 31   | `InvalidFeePercentage`       | Admin          | `initialize`                       |
-/// | 32   | `InvalidWagerLimits`         | Admin          | `initialize`                       |
+/// | 30   | `Unauthorized`               | Admin          | `set_paused`, `set_treasury`, `set_wager_limits`, `set_fee` |
+/// | 31   | `InvalidFeePercentage`       | Admin          | `initialize`, `set_fee`            |
+/// | 32   | `InvalidWagerLimits`         | Admin          | `initialize`, `set_wager_limits`   |
 /// | 40   | `TransferFailed`             | Transfer       | `claim_winnings`                   |
 /// | 50   | `AdminTreasuryConflict`      | Initialization | `initialize`                       |
 /// | 51   | `AlreadyInitialized`         | Initialization | `initialize`                       |
@@ -162,7 +162,7 @@ pub enum Error {
     // ── Action errors (20–21) ───────────────────────────────────────────────
 
     /// Player has no winnings to claim or continue (streak == 0 in Revealed phase).
-    /// Returned by: `continue_streak` (guard 3).
+    /// Returned by: `cash_out`, `claim_winnings`, `continue_streak`.
     /// Code: 20 — see [`error_codes::NO_WINNINGS_TO_CLAIM_OR_CONTINUE`]
     NoWinningsToClaimOrContinue = 20,
 
@@ -173,17 +173,18 @@ pub enum Error {
 
     // ── Admin errors (30–32) ────────────────────────────────────────────────
 
-    /// Caller is not authorized for admin operations (reserved).
+    /// Caller is not authorized for admin operations.
+    /// Returned by: `set_paused`, `set_treasury`, `set_wager_limits`, `set_fee`.
     /// Code: 30 — see [`error_codes::UNAUTHORIZED`]
     Unauthorized = 30,
 
     /// Fee percentage is outside the accepted range (200–500 bps / 2–5%).
-    /// Returned by: `initialize`.
+    /// Returned by: `initialize`, `set_fee`.
     /// Code: 31 — see [`error_codes::INVALID_FEE_PERCENTAGE`]
     InvalidFeePercentage = 31,
 
     /// Wager limits are invalid (`min_wager >= max_wager`).
-    /// Returned by: `initialize`.
+    /// Returned by: `initialize`, `set_wager_limits`.
     /// Code: 32 — see [`error_codes::INVALID_WAGER_LIMITS`]
     InvalidWagerLimits = 32,
 
@@ -298,30 +299,19 @@ pub struct ContractConfig {
     pub paused: bool,
 }
 
-<<<<<<< feature/cash-out-stats
-/// Global statistics tracking the overall economic activity and solvency of the contract.
-///
-/// Invariants and meaning:
-/// - `total_games`: The total number of games started. Strictly monotonically increasing.
-/// - `total_volume`: Total volume of wagers ever placed, denoted in stroops.
-/// - `total_fees`: Cumulative fee revenue collected by the protocol (never decreases).
-/// - `reserve_balance`: The contract's internal accounting of funds available to pay out winnings.
-///                      Must always be sufficient to cover the worst-case payout (10x wager)
-///                      to prevent insolvency. Decreases when players cash out or claim winnings,
-///                      increases when players lose and forfeit their wager.
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ContractStats {
-    pub total_games: u64,        // Total games played
-    pub total_volume: i128,      // Total XLM wagered
-    pub total_fees: i128,        // Cumulative fees collected in stroops
-    pub reserve_balance: i128,   // Available reserves to cover payouts
-=======
 /// Aggregate statistics stored in persistent storage under [`StorageKey::Stats`].
 ///
 /// Updated atomically alongside game state transitions.
 /// `reserve_balance` is the authoritative on-chain reserve figure used for
 /// solvency checks in `start_game` and `continue_streak`.
+///
+/// Invariants:
+/// - `total_games`: Strictly monotonically increasing; incremented in `start_game`.
+/// - `total_volume`: Cumulative wagers placed; never decreases.
+/// - `total_fees`: Cumulative protocol fees collected; never decreases (fees are never refunded).
+/// - `reserve_balance`: Must always be sufficient to cover the worst-case payout (10x wager).
+///   Decreases when players cash out or claim winnings (gross deducted), increases when players
+///   lose and forfeit their wager.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ContractStats {
@@ -334,7 +324,6 @@ pub struct ContractStats {
     /// Current contract reserve balance in stroops; decremented on payouts,
     /// incremented when the house wins (loss forfeiture).
     pub reserve_balance: i128,
->>>>>>> master
 }
 
 /// Persistent storage key variants for the contract's data model.
@@ -825,13 +814,15 @@ impl CoinflipContract {
     /// |------------------------|--------------------------------------------------------|
     /// | `NoActiveGame`         | No game record exists for `player`                     |
     /// | `InvalidPhase`         | Game is not in `Revealed` phase                        |
+    /// | `NoWinningsToClaimOrContinue` | `streak == 0` — loss state, nothing to claim    |
     /// | `InsufficientReserves` | `reserve_balance < gross_payout` or arithmetic overflow|
     /// | `TransferFailed`       | SAC token transfer fails (propagated from token client)|
     ///
     /// # Note on streak == 0
     /// A `Revealed` game with `streak == 0` indicates a loss; the game record is
-    /// deleted by `reveal` on the loss path, so `claim_winnings` will return
-    /// `NoActiveGame` rather than a dedicated loss error.
+    /// deleted by `reveal` on the loss path, so in practice `claim_winnings` will
+    /// return `NoActiveGame` for a lost game.  The explicit `streak == 0` guard
+    /// below defends against any injected state that bypasses the normal flow.
     pub fn claim_winnings(
         env: Env,
         player: Address,
@@ -844,6 +835,12 @@ impl CoinflipContract {
         // Must be in Revealed phase to claim (player won)
         if game.phase != GamePhase::Revealed {
             return Err(Error::InvalidPhase);
+        }
+
+        // streak == 0 in Revealed phase is a loss state — no winnings to claim.
+        // In normal flow this state is deleted by reveal, but guard defensively.
+        if game.streak == 0 {
+            return Err(Error::NoWinningsToClaimOrContinue);
         }
 
         let config = Self::load_config(&env);
@@ -862,51 +859,28 @@ impl CoinflipContract {
             return Err(Error::InsufficientReserves);
         }
 
-        // Transfer net payout to player
-        token_client.transfer(&env.current_contract_address(), &player, &net_payout);
-
-        // Transfer fee to treasury
-        token_client.transfer(&env.current_contract_address(), &config.treasury, &fee_amount);
-
-        // Update contract state
+        // Update accounting state BEFORE transfers so that if a transfer panics
+        // the reserve ledger is already consistent (Soroban aborts the entire
+        // transaction on panic, so partial state is never committed).
         let mut stats = stats;
         stats.reserve_balance = stats.reserve_balance.checked_sub(gross_payout)
             .ok_or(Error::InsufficientReserves)?;
         stats.total_fees = stats.total_fees.checked_add(fee_amount).unwrap_or(stats.total_fees);
         Self::save_stats(&env, &stats);
 
-        // Reset game to completed
+        // Mark game completed before transfers for the same reason.
         game.phase = GamePhase::Completed;
         Self::save_player_game(&env, &player, &game);
+
+        // Transfer net payout to player
+        token_client.transfer(&env.current_contract_address(), &player, &net_payout);
+
+        // Transfer fee to treasury
+        token_client.transfer(&env.current_contract_address(), &config.treasury, &fee_amount);
 
         Ok(())
     }
 
-<<<<<<< feature/cash-out-stats
-    /// Cash out winnings after a successful reveal (computes payout and cleans up state).
-    ///
-    /// # Pre-Execution Invariants & Guards
-    /// 1. `NoActiveGame`               – The player must have an active game in storage.
-    ///                                   If `cash_out` is called twice, the second call fails here
-    ///                                   because the first call completely deletes the game state.
-    /// 2. `InvalidPhase`               – The game phase must be `Revealed`.
-    /// 3. `NoWinningsToClaimOrContinue`– The player's streak must be > 0 (they must have won).
-    ///                                   A losing reveal resets the streak to 0.
-    /// 4. `InsufficientReserves`       – The contract must have enough `reserve_balance` to
-    ///                                   cover the `net_payout` calculation.
-    ///
-    /// # Post-Execution Invariants & Accounting
-    /// - **Protocol Fee**: The `fee` portion is permanently added to `stats.total_fees`.
-    /// - **Reserve Deduction**: `stats.reserve_balance` is decremented by exactly `net_payout`.
-    /// - **State Cleanup**: The player's game state is completely DELETED from storage.
-    ///                      No residual state is left.
-    ///
-    /// # Edge Cases
-    /// - **Double Cash Out**: Prevented by `delete_player_game` causing subsequent calls
-    ///                        to fail with `NoActiveGame`.
-    /// - **Zero Payouts**: If the computed net payout ends up being zero (e.g., due to rounding
-    ///                     or zero wager), the state is still cleared and no reserves are deducted.
-=======
     /// Cash out winnings after a successful reveal (accounting-only, no token transfer).
     ///
     /// Settles the game by updating reserve and fee accounting without issuing
@@ -930,7 +904,6 @@ impl CoinflipContract {
     /// | `InvalidPhase`                 | Game is not in `Revealed` phase                  |
     /// | `NoWinningsToClaimOrContinue`  | `streak == 0` — loss state, nothing to cash out  |
     /// | `InsufficientReserves`         | Arithmetic overflow in payout calculation        |
->>>>>>> master
     pub fn cash_out(
         env: Env,
         player: Address,
@@ -1775,6 +1748,27 @@ mod tests {
 
         let result = client.try_cash_out(&player);
         assert_eq!(result, Err(Ok(Error::NoWinningsToClaimOrContinue)));
+    }
+
+    #[test]
+    fn test_claim_winnings_rejects_losing_state_streak_zero() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, client) = setup(&env);
+
+        let player = Address::generate(&env);
+        // Inject a Revealed game with streak == 0 (loss state).
+        inject_game(&env, &contract_id, &player, GamePhase::Revealed, 0, 10_000_000);
+
+        let result = client.try_claim_winnings(&player);
+        assert_eq!(result, Err(Ok(Error::NoWinningsToClaimOrContinue)));
+
+        // State must be unchanged — no partial mutation.
+        let game: GameState = env.as_contract(&contract_id, || {
+            CoinflipContract::load_player_game(&env, &player).unwrap()
+        });
+        assert_eq!(game.phase, GamePhase::Revealed);
+        assert_eq!(game.streak, 0);
     }
 
     // ── Happy path ───────────────────────────────────────────────────────────


### PR DESCRIPTION
fix: consistent error codes across all public entrypoints

Audited every public contract entrypoint and fixed all edge cases where the wrong or missing error code would be 
returned.

Bug fixes

- claim_winnings: added missing NoWinningsToClaimOrContinue guard for streak == 0 in Revealed phase. Without this, an 
injected loss-state game would hit calculate_payout_breakdown with streak=0, fall through to the 10x wildcard 
multiplier, and pay out incorrectly instead of rejecting.
- claim_winnings: moved reserve accounting and game phase writes to storage before token transfers. State is now 
consistent with the correct Soroban pattern regardless of transfer outcome.
- Resolved two unresolved <<<<<<< / >>>>>>> merge conflict markers left in doc comments for ContractStats and cash_out
— these would break cargo doc.

Documentation

- error_codes table: Unauthorized was marked (reserved) — it is returned by all four admin functions. 
NoWinningsToClaimOrContinue now lists cash_out and claim_winnings in addition to continue_streak. InvalidFeePercentage
and InvalidWagerLimits now include set_fee and set_wager_limits.
- Error enum variant doc comments updated to match actual return sites.

Tests

- Added test_claim_winnings_rejects_losing_state_streak_zero: verifies the new guard returns the correct error and 
produces no state mutation on rejection.

Error code guard order (all entrypoints)

| Entrypoint | Guard sequence |
|---|---|
| initialize | AlreadyInitialized → AdminTreasuryConflict → InvalidFeePercentage → InvalidWagerLimits |
| start_game | ContractPaused → WagerBelowMinimum → WagerAboveMaximum → ActiveGameExists → InsufficientReserves |
| reveal | NoActiveGame → InvalidPhase → CommitmentMismatch |
| cash_out | NoActiveGame → InvalidPhase → NoWinningsToClaimOrContinue → InsufficientReserves |
| claim_winnings | NoActiveGame → InvalidPhase → NoWinningsToClaimOrContinue → InsufficientReserves |
| continue_streak | NoActiveGame → InvalidPhase → NoWinningsToClaimOrContinue → InvalidCommitment → 
InsufficientReserves |
| set_paused | Unauthorized |
| set_treasury | Unauthorized |
| set_wager_limits | Unauthorized → InvalidWagerLimits |
| set_fee | Unauthorized → InvalidFeePercentage |

Closes #147 