### PR TITLE
feat: implement hero section with proof card

### DIFF
--- a/frontend/components/HeroSection.module.css
+++ b/frontend/components/HeroSection.module.css
@@ -1,0 +1,130 @@
+.section {
+  background: var(--color-bg-base);
+  padding: var(--space-16) var(--space-8);
+}
+
+.grid {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 7fr 5fr;
+  gap: var(--space-16);
+  align-items: center;
+}
+
+.copy {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+}
+
+.headline {
+  font-family: var(--font-display);
+  font-size: var(--font-size-hero);
+  font-weight: 700;
+  line-height: var(--line-height-tight);
+  color: var(--color-fg-primary);
+  margin: 0;
+}
+
+.body {
+  font-family: var(--font-body);
+  font-size: var(--font-size-body);
+  line-height: var(--line-height-relaxed);
+  color: var(--color-fg-secondary);
+  max-width: 52ch;
+  margin: 0;
+}
+
+.ctas {
+  display: flex;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+}
+
+.ctaPrimary {
+  font-family: var(--font-body);
+  font-size: var(--font-size-body);
+  font-weight: 500;
+  background: var(--interactive-primary-bg);
+  color: var(--interactive-primary-fg);
+  border: none;
+  border-radius: var(--radius-md);
+  padding: var(--space-3) var(--space-8);
+  cursor: pointer;
+  transition: opacity var(--motion-fast) var(--ease-standard);
+  min-height: 44px;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+}
+
+.ctaPrimary:hover {
+  opacity: 0.85;
+}
+
+.ctaSecondary {
+  font-family: var(--font-body);
+  font-size: var(--font-size-body);
+  font-weight: 500;
+  background: transparent;
+  color: var(--color-fg-primary);
+  border: 1px solid var(--interactive-secondary-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-3) var(--space-8);
+  cursor: pointer;
+  transition: border-color var(--motion-fast) var(--ease-standard);
+  min-height: 44px;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+}
+
+.ctaSecondary:hover {
+  border-color: var(--color-fg-primary);
+}
+
+.ctaPrimary:focus-visible,
+.ctaSecondary:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.trustStrip {
+  max-width: 1200px;
+  margin: var(--space-12) auto 0;
+  display: flex;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+}
+
+.trustChip {
+  font-family: var(--font-body);
+  font-size: var(--font-size-sm);
+  color: var(--color-fg-secondary);
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-pill);
+  padding: var(--space-2) var(--space-4);
+}
+
+/* Mobile: stack vertically */
+@media (max-width: 768px) {
+  .section {
+    padding: var(--space-12) var(--space-6);
+  }
+
+  .grid {
+    grid-template-columns: 1fr;
+    gap: var(--space-8);
+  }
+
+  .headline {
+    font-size: clamp(2.25rem, 10vw, 3.5rem);
+  }
+
+  .trustStrip {
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+}

--- a/frontend/components/HeroSection.tsx
+++ b/frontend/components/HeroSection.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { ProofCard } from "./ProofCard";
+import styles from "./HeroSection.module.css";
+
+const TRUST_CHIPS = [
+  "Provably Fair Commit-Reveal",
+  "On-Chain Soroban Settlement",
+  "2-5% Transparent Fee",
+];
+
+export function HeroSection() {
+  return (
+    <section className={styles.section} aria-label="Hero">
+      <div className={styles.grid}>
+        <div className={styles.copy}>
+          <h1 className={styles.headline}>
+            Trustless Coinflips.{" "}
+            <br />
+            Verifiable Outcomes.
+          </h1>
+          <p className={styles.body}>
+            Tossd is an onchain coinflip game built on Soroban. Every outcome is
+            auditable, every multiplier is explicit, and players choose when to
+            secure profit or risk a streak.
+          </p>
+          <div className={styles.ctas}>
+            <a href="#play" className={styles.ctaPrimary}>
+              Launch Tossd
+            </a>
+            <a
+              href="https://github.com/Tossd-Org/Tossd"
+              className={styles.ctaSecondary}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Audit Contract
+            </a>
+          </div>
+        </div>
+
+        <ProofCard />
+      </div>
+
+      <div className={styles.trustStrip} aria-label="Trust indicators">
+        {TRUST_CHIPS.map((chip) => (
+          <span key={chip} className={styles.trustChip}>
+            {chip}
+          </span>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/components/ProofCard.module.css
+++ b/frontend/components/ProofCard.module.css
@@ -1,0 +1,99 @@
+.card {
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+  padding: var(--space-8);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+
+  opacity: 0;
+  transform: translateY(12px);
+  animation: cardEnter var(--motion-slow) var(--ease-standard) 120ms forwards;
+}
+
+@keyframes cardEnter {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.label {
+  font-family: var(--font-body);
+  font-size: var(--font-size-xs);
+  color: var(--color-fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin: 0 0 var(--space-1);
+}
+
+.value {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-mono);
+  color: var(--color-fg-primary);
+  background: var(--color-bg-subtle);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2) var(--space-3);
+  word-break: break-all;
+  margin: 0;
+}
+
+.wagerRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.wagerAmount {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-h3);
+  font-weight: 600;
+  color: var(--color-fg-primary);
+}
+
+.sideBadge {
+  font-family: var(--font-body);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  background: var(--color-brand-accent-soft);
+  color: var(--color-brand-accent);
+  border-radius: var(--radius-pill);
+  padding: var(--space-1) var(--space-3);
+}
+
+.outcomeChip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-family: var(--font-body);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  border-radius: var(--radius-pill);
+  padding: var(--space-2) var(--space-4);
+}
+
+.outcomeChip.win {
+  background: #e8f5ee;
+  color: var(--color-state-success);
+}
+
+.multiplier {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--color-brand-accent);
+  background: var(--color-brand-accent-soft);
+  border-radius: var(--radius-pill);
+  padding: var(--space-1) var(--space-3);
+}

--- a/frontend/components/ProofCard.tsx
+++ b/frontend/components/ProofCard.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import styles from "./ProofCard.module.css";
+
+const MOCK = {
+  wager: "2.00 XLM",
+  side: "Heads",
+  commitHash: "0x3a7f…c91b",
+  revealSecret: "0x8d2e…44fa",
+  outcome: "Win",
+  multiplier: "1.9×",
+};
+
+export function ProofCard() {
+  return (
+    <div className={styles.card} aria-label="Proof card mock">
+      <div className={styles.wagerRow}>
+        <span className={styles.wagerAmount}>{MOCK.wager}</span>
+        <span className={styles.sideBadge}>{MOCK.side}</span>
+      </div>
+
+      <div>
+        <p className={styles.label}>Commit hash</p>
+        <p className={styles.value}>{MOCK.commitHash}</p>
+      </div>
+
+      <div>
+        <p className={styles.label}>Reveal secret</p>
+        <p className={styles.value}>{MOCK.revealSecret}</p>
+      </div>
+
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <span className={`${styles.outcomeChip} ${styles.win}`}>
+          ✓ {MOCK.outcome}
+        </span>
+        <span className={styles.multiplier}>{MOCK.multiplier}</span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- HeroSection: 7/5 column desktop grid, stacks on mobile (<768px)
- ProofCard: commit/reveal mock with animated entrance (upward fade)
- Trust strip with 3 chips below hero
- Primary (Launch Tossd) and secondary (Audit Contract) CTAs
- Respects prefers-reduced-motion
- All tokens from frontend/tokens/tossd.tokens.css

Closes #292