### PR TITLE
feat: create trust strip component

### DIFF
--- a/frontend/components/TrustStrip.module.css
+++ b/frontend/components/TrustStrip.module.css
@@ -1,0 +1,32 @@
+.strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-family: var(--font-body);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  color: var(--color-brand-accent);
+  background: var(--color-brand-accent-soft);
+  border-radius: var(--radius-pill);
+  padding: var(--space-2) var(--space-4);
+}
+
+.icon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+@media (max-width: 768px) {
+  .strip {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-2);
+  }
+}

--- a/frontend/components/TrustStrip.tsx
+++ b/frontend/components/TrustStrip.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import styles from "./TrustStrip.module.css";
+
+const INDICATORS = [
+  {
+    label: "Provably Fair Commit-Reveal",
+    icon: (
+      <svg className={styles.icon} viewBox="0 0 16 16" fill="none" aria-hidden="true">
+        <path d="M8 1L2 4v4c0 3.3 2.5 5.7 6 7 3.5-1.3 6-3.7 6-7V4L8 1z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round"/>
+        <path d="M5.5 8l1.8 1.8L10.5 6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+      </svg>
+    ),
+  },
+  {
+    label: "On-Chain Soroban Settlement",
+    icon: (
+      <svg className={styles.icon} viewBox="0 0 16 16" fill="none" aria-hidden="true">
+        <rect x="2" y="5" width="12" height="8" rx="1.5" stroke="currentColor" strokeWidth="1.5"/>
+        <path d="M5 5V4a3 3 0 016 0v1" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+      </svg>
+    ),
+  },
+  {
+    label: "2–5% Transparent Fee",
+    icon: (
+      <svg className={styles.icon} viewBox="0 0 16 16" fill="none" aria-hidden="true">
+        <circle cx="5.5" cy="5.5" r="1.5" stroke="currentColor" strokeWidth="1.5"/>
+        <circle cx="10.5" cy="10.5" r="1.5" stroke="currentColor" strokeWidth="1.5"/>
+        <path d="M3 13L13 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+      </svg>
+    ),
+  },
+];
+
+export function TrustStrip() {
+  return (
+    <ul className={styles.strip} aria-label="Trust indicators" role="list">
+      {INDICATORS.map(({ label, icon }) => (
+        <li key={label} className={styles.chip}>
+          {icon}
+          <span>{label}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}


### PR DESCRIPTION
- TrustStrip: horizontal flex strip on desktop, stacked chips on mobile (<768px)
- Three indicators: Provably Fair, On-Chain Settlement, Transparent Fee
- Inline SVG icons with aria-hidden; ul/li with aria-label for screen readers
- accent-soft background + accent color tokens per design system
- pill border-radius from --radius-pill token

Closes #293