### PR TITLE
feat: build fairness timeline component

### DIFF
--- a/frontend/components/FairnessTimeline.module.css
+++ b/frontend/components/FairnessTimeline.module.css
@@ -1,0 +1,92 @@
+.timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.step {
+  display: grid;
+  grid-template-columns: 40px 1fr;
+  gap: 0 var(--space-4);
+}
+
+/* Left column: badge + connector line */
+.rail {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.badge {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--color-brand-accent-soft);
+  color: var(--color-brand-accent);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.connector {
+  width: 2px;
+  flex: 1;
+  min-height: var(--space-8);
+  background: var(--color-border-default);
+  margin: var(--space-2) 0;
+}
+
+.step:last-child .connector {
+  display: none;
+}
+
+/* Right column: content */
+.content {
+  padding-bottom: var(--space-8);
+}
+
+.step:last-child .content {
+  padding-bottom: 0;
+}
+
+.icon {
+  width: 18px;
+  height: 18px;
+  color: var(--color-brand-accent);
+  margin-bottom: var(--space-2);
+}
+
+.title {
+  font-family: var(--font-body);
+  font-size: var(--font-size-h3);
+  font-weight: 600;
+  color: var(--color-fg-primary);
+  margin: 0 0 var(--space-2);
+}
+
+.caption {
+  font-family: var(--font-body);
+  font-size: var(--font-size-sm);
+  color: var(--color-fg-secondary);
+  line-height: var(--line-height-relaxed);
+  margin: 0 0 var(--space-3);
+}
+
+.hash {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--color-fg-secondary);
+  background: var(--color-bg-subtle);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2) var(--space-3);
+  display: inline-block;
+  word-break: break-all;
+}

--- a/frontend/components/FairnessTimeline.tsx
+++ b/frontend/components/FairnessTimeline.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import styles from "./FairnessTimeline.module.css";
+
+const STEPS = [
+  {
+    title: "Commit",
+    caption: "Player submits a hash of their secret before the flip. The contract cannot know the secret in advance.",
+    example: "commitHash: 0x3a7f…c91b",
+    icon: (
+      <svg className={styles.icon} viewBox="0 0 18 18" fill="none" aria-hidden="true">
+        <rect x="3" y="5" width="12" height="9" rx="1.5" stroke="currentColor" strokeWidth="1.5"/>
+        <path d="M6 5V4a3 3 0 016 0v1" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+      </svg>
+    ),
+  },
+  {
+    title: "Reveal",
+    caption: "Player reveals their secret. The on-chain XOR of both secrets determines the outcome — neither party can bias it.",
+    example: "revealSecret: 0x8d2e…44fa",
+    icon: (
+      <svg className={styles.icon} viewBox="0 0 18 18" fill="none" aria-hidden="true">
+        <circle cx="9" cy="9" r="3" stroke="currentColor" strokeWidth="1.5"/>
+        <path d="M2 9c1.8-4 10.2-4 14 0-3.8 4-12.2 4-14 0z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round"/>
+      </svg>
+    ),
+  },
+  {
+    title: "Settle",
+    caption: "Payout is computed deterministically on-chain. The result is auditable by anyone with the transaction ID.",
+    example: "txId: 0xf19c…7a30",
+    icon: (
+      <svg className={styles.icon} viewBox="0 0 18 18" fill="none" aria-hidden="true">
+        <path d="M3.5 9.5l3.5 3.5 7.5-7.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+      </svg>
+    ),
+  },
+];
+
+export function FairnessTimeline() {
+  return (
+    <ol className={styles.timeline} aria-label="Commit-reveal fairness steps">
+      {STEPS.map((step, i) => (
+        <li key={step.title} className={styles.step}>
+          <div className={styles.rail} aria-hidden="true">
+            <span className={styles.badge}>{i + 1}</span>
+            <span className={styles.connector} />
+          </div>
+          <div className={styles.content}>
+            {step.icon}
+            <h3 className={styles.title}>{step.title}</h3>
+            <p className={styles.caption}>{step.caption}</p>
+            <span className={styles.hash}>{step.example}</span>
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+}


### PR DESCRIPTION
Implements the numbered commit-reveal timeline for the fairness section of the landing 
page.

### Changes

- **FairnessTimeline.tsx** — vertical 3-step <ol> (Commit → Reveal → Settle). Each step 
uses a two-column grid: numbered badge + connector line on the left, icon/title/caption/
hash on the right.
- **FairnessTimeline.module.css** — connector line hidden on last step, all values from 
tossd.tokens.css.

### Accessibility

- <ol> carries aria-label="Commit-reveal fairness steps" for screen readers
- Step numbers are in visible DOM order — no skip
- SVG icons are aria-hidden

### Design tokens used

--color-brand-accent-soft, --color-brand-accent, --color-border-default, --color-bg-subtle,
--font-mono, --radius-sm

### Screenshots

│ Add desktop + mobile screenshots before merging.


Closes #294
