### PR TITLE
feat: build error boundary component

### DIFF
--- a/frontend/components/ErrorBoundary.module.css
+++ b/frontend/components/ErrorBoundary.module.css
@@ -1,0 +1,108 @@
+@import "../tokens/tossd.tokens.css";
+
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-8);
+  max-width: 36rem;
+  margin: var(--space-6) auto;
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-lg);
+  border-top: 4px solid var(--color-state-danger);
+  box-shadow: var(--shadow-card);
+}
+
+.title {
+  margin: 0;
+  font-family: var(--font-body);
+  font-size: var(--font-size-h3);
+  font-weight: 600;
+  color: var(--color-fg-primary);
+  line-height: var(--line-height-tight);
+}
+
+.lead {
+  margin: 0;
+  font-family: var(--font-body);
+  font-size: var(--font-size-body);
+  color: var(--color-fg-secondary);
+  line-height: var(--line-height-relaxed);
+}
+
+.details {
+  margin: 0;
+  padding: var(--space-3) var(--space-4);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-mono);
+  color: var(--color-fg-primary);
+  background: var(--color-bg-subtle);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-sm);
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  margin-top: var(--space-2);
+}
+
+.btn {
+  font-family: var(--font-body);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition:
+    background-color var(--motion-fast) var(--ease-standard),
+    border-color var(--motion-fast) var(--ease-standard),
+    color var(--motion-fast) var(--ease-standard);
+}
+
+.btn:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.btnPrimary {
+  background: var(--color-brand-ink);
+  color: var(--color-bg-surface);
+}
+
+.btnPrimary:hover {
+  filter: brightness(1.08);
+}
+
+.btnSecondary {
+  background: transparent;
+  color: var(--color-fg-primary);
+  border-color: var(--color-border-strong);
+}
+
+.btnSecondary:hover {
+  background: var(--color-bg-subtle);
+}
+
+@media (max-width: 480px) {
+  .root {
+    margin: var(--space-4);
+    padding: var(--space-6);
+  }
+
+  .actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .btn {
+    width: 100%;
+    text-align: center;
+  }
+}

--- a/frontend/components/ErrorBoundary.tsx
+++ b/frontend/components/ErrorBoundary.tsx
@@ -1,0 +1,142 @@
+import React, { Component, ErrorInfo, ReactNode, useEffect, useRef } from "react";
+import styles from "./ErrorBoundary.module.css";
+
+function normalizeError(error: unknown): Error {
+  if (error instanceof Error) return error;
+  return new Error(typeof error === "string" ? error : "Unknown error");
+}
+
+export type ErrorBoundaryFallbackProps = {
+  error: Error;
+  resetErrorBoundary: () => void;
+};
+
+export interface ErrorBoundaryProps {
+  children: ReactNode;
+  /** Custom fallback, or a render prop receiving error + reset. */
+  fallback?:
+    | ReactNode
+    | ((props: ErrorBoundaryFallbackProps) => ReactNode);
+  /** Called after `console.error` — e.g. send to your logging backend. */
+  onError?: (error: Error, errorInfo: ErrorInfo) => void;
+  /** Called after a successful reset (Try again). */
+  onReset?: () => void;
+  /** When any entry changes vs the previous render, the boundary resets. */
+  resetKeys?: ReadonlyArray<unknown>;
+  /** Show `error.message` in the default fallback (off in production if you prefer). */
+  showDetails?: boolean;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+function resetKeysChanged(
+  prev: ReadonlyArray<unknown> | undefined,
+  next: ReadonlyArray<unknown> | undefined
+): boolean {
+  if (!prev?.length || !next?.length || prev.length !== next.length) return false;
+  return next.some((key, i) => key !== prev[i]);
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false, error: null };
+
+  static getDerivedStateFromError(error: unknown): Partial<ErrorBoundaryState> {
+    return { hasError: true, error: normalizeError(error) };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    console.error("[ErrorBoundary]", error, errorInfo.componentStack);
+    this.props.onError?.(error, errorInfo);
+  }
+
+  componentDidUpdate(prevProps: ErrorBoundaryProps): void {
+    const { hasError } = this.state;
+    if (!hasError) return;
+    if (resetKeysChanged(prevProps.resetKeys, this.props.resetKeys)) {
+      this.reset();
+    }
+  }
+
+  reset = (): void => {
+    this.setState({ hasError: false, error: null });
+    this.props.onReset?.();
+  };
+
+  render(): ReactNode {
+    const { hasError, error } = this.state;
+    if (hasError && error) {
+      const fallbackProps: ErrorBoundaryFallbackProps = {
+        error,
+        resetErrorBoundary: this.reset,
+      };
+      const { fallback, showDetails } = this.props;
+      if (typeof fallback === "function") {
+        return fallback(fallbackProps);
+      }
+      if (fallback != null) {
+        return fallback;
+      }
+      return (
+        <DefaultErrorFallback {...fallbackProps} showDetails={showDetails ?? false} />
+      );
+    }
+    return this.props.children;
+  }
+}
+
+type DefaultErrorFallbackProps = ErrorBoundaryFallbackProps & {
+  showDetails: boolean;
+};
+
+export function DefaultErrorFallback({
+  error,
+  resetErrorBoundary,
+  showDetails,
+}: DefaultErrorFallbackProps) {
+  const titleRef = useRef<HTMLHeadingElement>(null);
+
+  useEffect(() => {
+    titleRef.current?.focus();
+  }, []);
+
+  return (
+    <section
+      className={styles.root}
+      role="alert"
+      aria-live="assertive"
+      aria-atomic="true"
+      {...(showDetails ? { "aria-describedby": "error-boundary-message" } : {})}
+    >
+      <h2 ref={titleRef} tabIndex={-1} className={styles.title}>
+        Something went wrong
+      </h2>
+      <p className={styles.lead}>
+        This section could not be displayed. You can try again or reload the page.
+      </p>
+      {showDetails ? (
+        <pre className={styles.details} id="error-boundary-message">
+          {error.message}
+        </pre>
+      ) : null}
+      <div className={styles.actions}>
+        <button
+          type="button"
+          className={`${styles.btn} ${styles.btnPrimary}`}
+          onClick={resetErrorBoundary}
+        >
+          Try again
+        </button>
+        <button
+          type="button"
+          className={`${styles.btn} ${styles.btnSecondary}`}
+          onClick={() => window.location.reload()}
+        >
+          Reload page
+        </button>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
Closes #314

---

Adds a reusable React error boundary so subtree failures surface a controlled fallback instead of a blank tree. Errors are logged with console.error and can be forwarded via onError. The default UI matches Tossd tokens, is responsive, and supports recovery via Try again (reset boundary + optional onReset) and Reload page. resetKeys clears the error when inputs change (e.g. route or tab id).
