### PR TITLE
feat: create transaction history list

### DIFF
--- a/frontend/components/TransactionHistory.module.css
+++ b/frontend/components/TransactionHistory.module.css
@@ -1,0 +1,182 @@
+@import "../tokens/tossd.tokens.css";
+
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.heading {
+  font-family: var(--font-body);
+  font-size: var(--font-size-h3);
+  font-weight: 600;
+  color: var(--color-fg-primary);
+  margin: 0;
+}
+
+.empty {
+  font-family: var(--font-body);
+  font-size: var(--font-size-sm);
+  color: var(--color-fg-muted);
+  text-align: center;
+  padding: var(--space-12) 0;
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding: var(--space-3) var(--space-4);
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-md);
+  flex-wrap: wrap;
+}
+
+.rowLeft {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.rowRight {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+}
+
+/* Outcome chips */
+.chip {
+  display: inline-flex;
+  align-items: center;
+  border-radius: var(--radius-pill);
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  font-family: var(--font-body);
+  white-space: nowrap;
+}
+
+.chip--win {
+  color: var(--color-state-success);
+  background: color-mix(in srgb, var(--color-state-success) 10%, white);
+}
+
+.chip--loss {
+  color: var(--color-state-danger);
+  background: color-mix(in srgb, var(--color-state-danger) 10%, white);
+}
+
+.chip--pending {
+  color: var(--color-state-info);
+  background: color-mix(in srgb, var(--color-state-info) 10%, white);
+}
+
+.meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.side {
+  font-family: var(--font-body);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  color: var(--color-fg-primary);
+  text-transform: capitalize;
+}
+
+.streak {
+  font-family: var(--font-body);
+  font-size: var(--font-size-xs);
+  color: var(--color-fg-muted);
+}
+
+.mono {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-mono);
+  color: var(--color-fg-secondary);
+  white-space: nowrap;
+}
+
+.payout {
+  color: var(--color-state-success);
+}
+
+.time {
+  font-family: var(--font-body);
+  font-size: var(--font-size-xs);
+  color: var(--color-fg-muted);
+  white-space: nowrap;
+}
+
+/* Infinite scroll sentinel */
+.sentinel {
+  height: 1px;
+}
+
+/* Pagination */
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-4);
+  padding-top: var(--space-2);
+}
+
+.pageBtn {
+  min-height: 44px;
+  padding: 0 var(--space-4);
+  background: transparent;
+  border: 1px solid var(--interactive-secondary-border);
+  border-radius: var(--radius-md);
+  font-family: var(--font-body);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  color: var(--color-fg-primary);
+  cursor: pointer;
+  transition: background var(--motion-fast) var(--ease-standard);
+}
+
+.pageBtn:hover:not(:disabled) {
+  background: var(--color-bg-subtle);
+}
+
+.pageBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.pageBtn:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.pageInfo {
+  font-family: var(--font-body);
+  font-size: var(--font-size-sm);
+  color: var(--color-fg-muted);
+}
+
+/* Responsive */
+@media (max-width: 480px) {
+  .row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .rowRight {
+    gap: var(--space-2);
+  }
+}

--- a/frontend/components/TransactionHistory.tsx
+++ b/frontend/components/TransactionHistory.tsx
@@ -1,0 +1,162 @@
+import React, { useCallback, useRef, useState } from "react";
+import styles from "./TransactionHistory.module.css";
+
+export type GameOutcome = "win" | "loss" | "pending";
+export type CoinSide = "heads" | "tails";
+
+export interface GameRecord {
+  id: string;
+  timestamp: number; // Unix ms
+  side: CoinSide;
+  wagerStroops: number;
+  payoutStroops: number | null; // null when pending or loss
+  outcome: GameOutcome;
+  streak: number;
+  txHash?: string;
+}
+
+interface TransactionRowProps {
+  record: GameRecord;
+}
+
+function formatXLM(stroops: number): string {
+  return (stroops / 10_000_000).toFixed(7).replace(/\.?0+$/, "") + " XLM";
+}
+
+function formatDate(ts: number): string {
+  return new Date(ts).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function OutcomeChip({ outcome }: { outcome: GameOutcome }) {
+  const label = outcome === "win" ? "Win" : outcome === "loss" ? "Loss" : "Pending";
+  return (
+    <span className={`${styles.chip} ${styles[`chip--${outcome}`]}`}>
+      {label}
+    </span>
+  );
+}
+
+function TransactionRow({ record }: TransactionRowProps) {
+  return (
+    <li className={styles.row}>
+      <div className={styles.rowLeft}>
+        <OutcomeChip outcome={record.outcome} />
+        <span className={styles.meta}>
+          <span className={styles.side}>{record.side}</span>
+          {record.streak > 0 && (
+            <span className={styles.streak}>×{record.streak + 1} streak</span>
+          )}
+        </span>
+      </div>
+      <div className={styles.rowRight}>
+        <span className={styles.mono}>{formatXLM(record.wagerStroops)}</span>
+        {record.payoutStroops != null && (
+          <span className={`${styles.mono} ${styles.payout}`}>
+            +{formatXLM(record.payoutStroops)}
+          </span>
+        )}
+        <time className={styles.time} dateTime={new Date(record.timestamp).toISOString()}>
+          {formatDate(record.timestamp)}
+        </time>
+      </div>
+    </li>
+  );
+}
+
+const PAGE_SIZE = 20;
+
+export interface TransactionHistoryProps {
+  records: GameRecord[];
+  /** Use "paginate" for explicit prev/next, "infinite" for scroll-based loading. */
+  mode?: "paginate" | "infinite";
+}
+
+export function TransactionHistory({
+  records,
+  mode = "infinite",
+}: TransactionHistoryProps) {
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const [page, setPage] = useState(0);
+
+  // Reverse-chronological order
+  const sorted = [...records].sort((a, b) => b.timestamp - a.timestamp);
+
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  const loadMore = useCallback(() => {
+    setVisibleCount((c) => Math.min(c + PAGE_SIZE, sorted.length));
+  }, [sorted.length]);
+
+  // Infinite scroll via IntersectionObserver
+  React.useEffect(() => {
+    if (mode !== "infinite") return;
+    const el = sentinelRef.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => { if (entry.isIntersecting) loadMore(); },
+      { threshold: 0.1 }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [mode, loadMore]);
+
+  if (records.length === 0) {
+    return (
+      <section className={styles.container} aria-label="Transaction history">
+        <p className={styles.empty}>No games played yet.</p>
+      </section>
+    );
+  }
+
+  const paginatedRecords =
+    mode === "paginate"
+      ? sorted.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE)
+      : sorted.slice(0, visibleCount);
+
+  const totalPages = Math.ceil(sorted.length / PAGE_SIZE);
+  const hasMore = mode === "infinite" && visibleCount < sorted.length;
+
+  return (
+    <section className={styles.container} aria-label="Transaction history">
+      <h2 className={styles.heading}>Game History</h2>
+      <ul className={styles.list} role="list">
+        {paginatedRecords.map((r) => (
+          <TransactionRow key={r.id} record={r} />
+        ))}
+      </ul>
+
+      {mode === "infinite" && hasMore && (
+        <div ref={sentinelRef} className={styles.sentinel} aria-hidden="true" />
+      )}
+
+      {mode === "paginate" && totalPages > 1 && (
+        <nav className={styles.pagination} aria-label="History pages">
+          <button
+            className={styles.pageBtn}
+            onClick={() => setPage((p) => p - 1)}
+            disabled={page === 0}
+            aria-label="Previous page"
+          >
+            ← Prev
+          </button>
+          <span className={styles.pageInfo}>
+            {page + 1} / {totalPages}
+          </span>
+          <button
+            className={styles.pageBtn}
+            onClick={() => setPage((p) => p + 1)}
+            disabled={page >= totalPages - 1}
+            aria-label="Next page"
+          >
+            Next →
+          </button>
+        </nav>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
### create-transaction-history-list
TransactionHistory.tsx + TransactionHistory.module.css
- Reverse-chronological sort built in
- OutcomeChip with win/loss/pending semantic colors
- Wager and payout in --font-mono with XLM formatting
- Two modes: infinite (IntersectionObserver sentinel) and paginate (prev/next controls)
- Responsive — collapses to column layout on narrow screens
- closes #307