### PR TITLE
feat: implement game state card

### DIFF
--- a/frontend/components/GameStateCard.module.css
+++ b/frontend/components/GameStateCard.module.css
@@ -1,0 +1,194 @@
+@import "../tokens/tossd.tokens.css";
+
+.card {
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+  padding: var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.idle {
+  align-items: center;
+  justify-content: center;
+  min-height: 160px;
+}
+
+.idleText {
+  font-family: var(--font-body);
+  font-size: var(--font-size-sm);
+  color: var(--color-fg-muted);
+  text-align: center;
+  margin: 0;
+}
+
+/* Header */
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.phaseBadge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: var(--radius-pill);
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  font-family: var(--font-body);
+}
+
+.phaseWon {
+  color: var(--color-state-success);
+  background: color-mix(in srgb, var(--color-state-success) 10%, white);
+}
+
+.phaseLost {
+  color: var(--color-state-danger);
+  background: color-mix(in srgb, var(--color-state-danger) 10%, white);
+}
+
+.phaseNeutral {
+  color: var(--color-state-info);
+  background: color-mix(in srgb, var(--color-state-info) 10%, white);
+}
+
+.side {
+  font-family: var(--font-body);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  color: var(--color-fg-secondary);
+  text-transform: capitalize;
+}
+
+/* Stats */
+.stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-4);
+  margin: 0;
+  padding: var(--space-4);
+  background: var(--color-bg-subtle);
+  border-radius: var(--radius-md);
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.statLabel {
+  font-family: var(--font-body);
+  font-size: var(--font-size-xs);
+  color: var(--color-fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.statValue {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-mono);
+  font-weight: 600;
+  color: var(--color-fg-primary);
+  margin: 0;
+}
+
+.accent {
+  color: var(--color-brand-accent);
+}
+
+/* Pending tx */
+.txHash {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--color-fg-muted);
+  word-break: break-all;
+  margin: 0;
+}
+
+.txLabel {
+  font-weight: 600;
+}
+
+/* Actions */
+.actions {
+  display: flex;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  min-height: 44px;
+  padding: 0 var(--space-6);
+  border-radius: var(--radius-md);
+  font-family: var(--font-body);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity var(--motion-fast) var(--ease-standard);
+  flex: 1;
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.btnPrimary {
+  background: var(--interactive-primary-bg);
+  color: var(--interactive-primary-fg);
+  border: 1px solid var(--interactive-primary-bg);
+}
+
+.btnPrimary:hover:not(:disabled) {
+  opacity: 0.85;
+}
+
+.btnSecondary {
+  background: transparent;
+  color: var(--color-fg-primary);
+  border: 1px solid var(--interactive-secondary-border);
+}
+
+.btnSecondary:hover:not(:disabled) {
+  background: var(--color-bg-subtle);
+}
+
+/* Loading spinner */
+.spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: currentColor;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner { animation: none; }
+}
+
+@media (max-width: 400px) {
+  .stats {
+    grid-template-columns: 1fr 1fr;
+  }
+}

--- a/frontend/components/GameStateCard.tsx
+++ b/frontend/components/GameStateCard.tsx
@@ -1,0 +1,146 @@
+import React from "react";
+import styles from "./GameStateCard.module.css";
+
+export type GamePhase = "idle" | "committed" | "won" | "lost" | "timed_out";
+export type CoinSide = "heads" | "tails";
+
+export interface GameState {
+  phase: GamePhase;
+  side: CoinSide;
+  wagerStroops: number;
+  streak: number; // 0-based; 0 = first win pending
+  /** Pending tx hash for in-flight operations */
+  pendingTx?: string;
+}
+
+export interface GameStateCardProps {
+  game: GameState | null;
+  /** Called when player clicks Reveal */
+  onReveal?: () => void;
+  /** Called when player clicks Cash Out */
+  onCashOut?: () => void;
+  /** Called when player clicks Continue Streak */
+  onContinue?: () => void;
+  /** True while a blockchain tx is in-flight */
+  loading?: boolean;
+}
+
+const MULTIPLIERS: Record<number, string> = {
+  0: "1.9×",
+  1: "3.5×",
+  2: "6.0×",
+};
+
+function getMultiplier(streak: number): string {
+  return MULTIPLIERS[streak] ?? "10.0×";
+}
+
+function formatXLM(stroops: number): string {
+  return (stroops / 10_000_000).toFixed(7).replace(/\.?0+$/, "") + " XLM";
+}
+
+const PHASE_LABELS: Record<GamePhase, string> = {
+  idle: "No Active Game",
+  committed: "Awaiting Reveal",
+  won: "You Won!",
+  lost: "You Lost",
+  timed_out: "Timed Out",
+};
+
+export function GameStateCard({
+  game,
+  onReveal,
+  onCashOut,
+  onContinue,
+  loading = false,
+}: GameStateCardProps) {
+  if (!game || game.phase === "idle") {
+    return (
+      <div className={`${styles.card} ${styles.idle}`}>
+        <p className={styles.idleText}>Start a game to see your game state here.</p>
+      </div>
+    );
+  }
+
+  const { phase, side, wagerStroops, streak, pendingTx } = game;
+  const multiplier = getMultiplier(streak);
+
+  const phaseClass =
+    phase === "won"
+      ? styles.phaseWon
+      : phase === "lost" || phase === "timed_out"
+      ? styles.phaseLost
+      : styles.phaseNeutral;
+
+  return (
+    <div className={styles.card} aria-live="polite" aria-atomic="true">
+      {/* Phase badge */}
+      <div className={styles.header}>
+        <span className={`${styles.phaseBadge} ${phaseClass}`}>
+          {PHASE_LABELS[phase]}
+        </span>
+        <span className={`${styles.side}`}>{side}</span>
+      </div>
+
+      {/* Stats row */}
+      <dl className={styles.stats}>
+        <div className={styles.stat}>
+          <dt className={styles.statLabel}>Wager</dt>
+          <dd className={styles.statValue}>{formatXLM(wagerStroops)}</dd>
+        </div>
+        <div className={styles.stat}>
+          <dt className={styles.statLabel}>Multiplier</dt>
+          <dd className={`${styles.statValue} ${styles.accent}`}>{multiplier}</dd>
+        </div>
+        <div className={styles.stat}>
+          <dt className={styles.statLabel}>Streak</dt>
+          <dd className={styles.statValue}>{streak}</dd>
+        </div>
+      </dl>
+
+      {/* Pending tx */}
+      {pendingTx && (
+        <p className={styles.txHash}>
+          <span className={styles.txLabel}>Tx:</span> {pendingTx}
+        </p>
+      )}
+
+      {/* Actions */}
+      <div className={styles.actions}>
+        {phase === "committed" && (
+          <button
+            className={`${styles.btn} ${styles.btnPrimary}`}
+            onClick={onReveal}
+            disabled={loading}
+            aria-busy={loading}
+          >
+            {loading ? <span className={styles.spinner} aria-hidden="true" /> : null}
+            Reveal
+          </button>
+        )}
+
+        {phase === "won" && (
+          <>
+            <button
+              className={`${styles.btn} ${styles.btnPrimary}`}
+              onClick={onCashOut}
+              disabled={loading}
+              aria-busy={loading}
+            >
+              {loading ? <span className={styles.spinner} aria-hidden="true" /> : null}
+              Cash Out
+            </button>
+            <button
+              className={`${styles.btn} ${styles.btnSecondary}`}
+              onClick={onContinue}
+              disabled={loading}
+              aria-busy={loading}
+            >
+              Continue Streak
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### build-wallet-connection-modal
WalletModal.tsx + WalletModal.module.css
- Lists Freighter, Albedo, xBull, Rabet as selectable options
- Per-wallet spinner while connecting, error banner with role="alert" on failure
- Connected state shows wallet name + full public key address in monospace
- Focus trap + ESC key handled by the existing Modal base component
closes #306