### PR TITLE
feat: build side selector component

### DIFF
--- a/frontend/components/SideSelector.module.css
+++ b/frontend/components/SideSelector.module.css
@@ -1,0 +1,102 @@
+@import "../tokens/tossd.tokens.css";
+
+.group {
+  position: relative;
+  display: inline-grid;
+  grid-template-columns: 1fr 1fr;
+  background: var(--color-bg-subtle);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-pill);
+  padding: 4px;
+  gap: 0;
+  min-width: 220px;
+  user-select: none;
+}
+
+/* Sliding active indicator */
+.indicator {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  width: calc(50% - 4px);
+  height: calc(100% - 8px);
+  background: var(--color-brand-ink);
+  border-radius: var(--radius-pill);
+  transition: transform var(--motion-base) var(--ease-standard);
+  pointer-events: none;
+  z-index: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .indicator {
+    transition: none;
+  }
+}
+
+/* Each option */
+.option {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  min-height: 44px;
+  padding: 0 var(--space-4);
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  transition: color var(--motion-fast) var(--ease-standard);
+}
+
+.option:not(.selected) {
+  color: var(--color-fg-secondary);
+}
+
+.option.selected {
+  color: var(--color-bg-surface);
+}
+
+.option.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Focus ring on the hidden radio */
+.hiddenInput {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
+.hiddenInput:focus-visible + .symbol {
+  /* Bubble focus ring up to the label */
+  outline: none;
+}
+
+.option:has(.hiddenInput:focus-visible) {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.symbol {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  border: 1.5px solid currentColor;
+  flex-shrink: 0;
+  transition: border-color var(--motion-fast) var(--ease-standard);
+}
+
+.label {
+  font-family: var(--font-body);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+}

--- a/frontend/components/SideSelector.tsx
+++ b/frontend/components/SideSelector.tsx
@@ -1,0 +1,70 @@
+import React, { useId } from "react";
+import styles from "./SideSelector.module.css";
+
+export type CoinSide = "heads" | "tails";
+
+export interface SideSelectorProps {
+  value: CoinSide;
+  onChange: (side: CoinSide) => void;
+  disabled?: boolean;
+}
+
+const SIDES: { id: CoinSide; label: string; symbol: string }[] = [
+  { id: "heads", label: "Heads", symbol: "H" },
+  { id: "tails", label: "Tails", symbol: "T" },
+];
+
+export function SideSelector({ value, onChange, disabled = false }: SideSelectorProps) {
+  const groupId = useId();
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (disabled) return;
+    if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
+      e.preventDefault();
+      onChange(value === "heads" ? "tails" : "heads");
+    }
+  };
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Choose coin side"
+      className={styles.group}
+      onKeyDown={handleKeyDown}
+    >
+      {SIDES.map((side) => {
+        const inputId = `${groupId}-${side.id}`;
+        const isSelected = value === side.id;
+        return (
+          <label
+            key={side.id}
+            htmlFor={inputId}
+            className={`${styles.option} ${isSelected ? styles.selected : ""} ${disabled ? styles.disabled : ""}`}
+          >
+            <input
+              type="radio"
+              id={inputId}
+              name={groupId}
+              value={side.id}
+              checked={isSelected}
+              onChange={() => onChange(side.id)}
+              disabled={disabled}
+              className={styles.hiddenInput}
+            />
+            <span className={styles.symbol} aria-hidden="true">
+              {side.symbol}
+            </span>
+            <span className={styles.label}>{side.label}</span>
+          </label>
+        );
+      })}
+
+      {/* Sliding indicator */}
+      <span
+        className={styles.indicator}
+        style={{ transform: `translateX(${value === "tails" ? "100%" : "0%"})` }}
+        aria-hidden="true"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
### build-side-selector-component
SideSelector.tsx + SideSelector.module.css
- Sliding pill indicator animates between Heads/Tails via CSS transform
- Built on role="radiogroup" + hidden radio inputs — fully screen-reader compatible
- Arrow key navigation (←/→) switches selection
- Focus ring via :has(.hiddenInput:focus-visible) on the label
- prefers-reduced-motion disables the slide animation
- closes #305