### PR TITLE
feat: create Footer component (#301)

### DIFF
--- a/frontend/components/Footer.module.css
+++ b/frontend/components/Footer.module.css
@@ -1,0 +1,195 @@
+.footer {
+  background: var(--color-brand-ink);
+  color: var(--color-bg-surface);
+  padding: var(--space-16) var(--space-8) var(--space-8);
+}
+
+.inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-12);
+}
+
+/* Top section: brand + nav columns */
+.top {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr;
+  gap: var(--space-12);
+}
+
+/* Brand column */
+.brand {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.logo {
+  font-family: var(--font-display);
+  font-size: var(--font-size-h3);
+  font-weight: 700;
+  color: var(--color-bg-surface);
+  text-decoration: none;
+  letter-spacing: -0.01em;
+}
+
+.logo:hover {
+  opacity: 0.85;
+}
+
+.tagline {
+  font-family: var(--font-body);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-relaxed);
+  color: rgba(255, 255, 255, 0.55);
+  margin: 0;
+  max-width: 36ch;
+}
+
+/* Social icons */
+.social {
+  display: flex;
+  gap: var(--space-3);
+  margin-top: var(--space-2);
+}
+
+.socialLink {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: var(--radius-sm);
+  color: rgba(255, 255, 255, 0.6);
+  transition: color var(--motion-fast) var(--ease-standard),
+    background var(--motion-fast) var(--ease-standard);
+}
+
+.socialLink:hover {
+  color: var(--color-bg-surface);
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.socialLink:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+/* Nav / resource columns */
+.colHeading {
+  font-family: var(--font-body);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.4);
+  margin: 0 0 var(--space-4);
+}
+
+.navList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.navLink {
+  font-family: var(--font-body);
+  font-size: var(--font-size-sm);
+  color: rgba(255, 255, 255, 0.65);
+  text-decoration: none;
+  transition: color var(--motion-fast) var(--ease-standard);
+}
+
+.navLink:hover {
+  color: var(--color-bg-surface);
+}
+
+.navLink:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+/* Bottom bar */
+.bottom {
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  padding-top: var(--space-8);
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-8);
+}
+
+.disclaimer {
+  font-family: var(--font-body);
+  font-size: var(--font-size-xs);
+  line-height: var(--line-height-relaxed);
+  color: rgba(255, 255, 255, 0.35);
+  margin: 0;
+  max-width: 60ch;
+  flex: 1;
+}
+
+.bottomRight {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+
+.copyright {
+  font-family: var(--font-body);
+  font-size: var(--font-size-xs);
+  color: rgba(255, 255, 255, 0.35);
+  margin: 0;
+  white-space: nowrap;
+}
+
+.legalLinks {
+  display: flex;
+  gap: var(--space-4);
+}
+
+.legalLink {
+  font-family: var(--font-body);
+  font-size: var(--font-size-xs);
+  color: rgba(255, 255, 255, 0.45);
+  text-decoration: none;
+  transition: color var(--motion-fast) var(--ease-standard);
+}
+
+.legalLink:hover {
+  color: var(--color-bg-surface);
+}
+
+.legalLink:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+/* Mobile: stack all columns */
+@media (max-width: 768px) {
+  .footer {
+    padding: var(--space-12) var(--space-6) var(--space-8);
+  }
+
+  .top {
+    grid-template-columns: 1fr;
+    gap: var(--space-8);
+  }
+
+  .bottom {
+    flex-direction: column;
+    gap: var(--space-6);
+  }
+
+  .bottomRight {
+    align-items: flex-start;
+  }
+}

--- a/frontend/components/Footer.tsx
+++ b/frontend/components/Footer.tsx
@@ -1,0 +1,148 @@
+import React from "react";
+import styles from "./Footer.module.css";
+
+const NAV_LINKS = [
+  { label: "How It Works", href: "#how-it-works" },
+  { label: "Economics", href: "#economics" },
+  { label: "Fairness", href: "#fairness" },
+  { label: "Security", href: "#security" },
+  { label: "Audit Contract", href: "https://github.com/Tossd-Org/Tossd", external: true },
+];
+
+const SOCIAL_LINKS = [
+  {
+    label: "GitHub",
+    href: "https://github.com/Tossd-Org/Tossd",
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d="M12 2C6.477 2 2 6.477 2 12c0 4.418 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.009-.868-.013-1.703-2.782.604-3.369-1.342-3.369-1.342-.454-1.154-1.11-1.462-1.11-1.462-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0 1 12 6.836a9.59 9.59 0 0 1 2.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.202 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.163 22 16.418 22 12c0-5.523-4.477-10-10-10z" />
+      </svg>
+    ),
+  },
+  {
+    label: "Twitter / X",
+    href: "https://twitter.com/TossdOrg",
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+      </svg>
+    ),
+  },
+  {
+    label: "Discord",
+    href: "https://discord.gg/tossd",
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
+      </svg>
+    ),
+  },
+];
+
+const LEGAL_LINKS = [
+  { label: "Terms of Service", href: "/terms" },
+  { label: "Privacy Policy", href: "/privacy" },
+];
+
+export function Footer() {
+  return (
+    <footer className={styles.footer} aria-label="Site footer">
+      <div className={styles.inner}>
+        <div className={styles.top}>
+          {/* Brand column */}
+          <div className={styles.brand}>
+            <a href="/" className={styles.logo} aria-label="Tossd home">
+              Tossd
+            </a>
+            <p className={styles.tagline}>
+              Trustless coinflips on Soroban. Every outcome provably fair, every
+              settlement on-chain.
+            </p>
+            <div className={styles.social} aria-label="Social media links">
+              {SOCIAL_LINKS.map(({ label, href, icon }) => (
+                <a
+                  key={label}
+                  href={href}
+                  className={styles.socialLink}
+                  aria-label={label}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {icon}
+                </a>
+              ))}
+            </div>
+          </div>
+
+          {/* Navigation column */}
+          <nav className={styles.nav} aria-label="Footer navigation">
+            <p className={styles.colHeading}>Navigation</p>
+            <ul className={styles.navList}>
+              {NAV_LINKS.map(({ label, href, external }) => (
+                <li key={label}>
+                  <a
+                    href={href}
+                    className={styles.navLink}
+                    {...(external
+                      ? { target: "_blank", rel: "noopener noreferrer" }
+                      : {})}
+                  >
+                    {label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </nav>
+
+          {/* Resources column */}
+          <div className={styles.resources}>
+            <p className={styles.colHeading}>Resources</p>
+            <ul className={styles.navList}>
+              <li>
+                <a
+                  href="https://github.com/Tossd-Org/Tossd"
+                  className={styles.navLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Open Source Contract
+                </a>
+              </li>
+              <li>
+                <a href="#how-it-works" className={styles.navLink}>
+                  Documentation
+                </a>
+              </li>
+              <li>
+                <a href="#fairness" className={styles.navLink}>
+                  Fairness Proof
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        {/* Bottom bar */}
+        <div className={styles.bottom}>
+          <p className={styles.disclaimer}>
+            Tossd is a provably fair on-chain game. Participation may be
+            restricted in certain jurisdictions. This is not financial advice.
+            Play responsibly — only wager what you can afford to lose.
+          </p>
+          <div className={styles.bottomRight}>
+            <p className={styles.copyright}>
+              &copy; {new Date().getFullYear()} Tossd. All rights reserved.
+            </p>
+            <div className={styles.legalLinks}>
+              {LEGAL_LINKS.map(({ label, href }) => (
+                <a key={label} href={href} className={styles.legalLink}>
+                  {label}
+                </a>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #301 

Builds the site footer with navigation links, social media icons, and legal/disclaimer text.

## Changes

- \`Footer.tsx\` — new component with brand column, navigation column, and resources column
- \`Footer.module.css\` — styles using design tokens from \`tossd.tokens.css\`

## Features implemented

- Multi-column layout on desktop (brand 2fr + nav 1fr + resources 1fr)
- Stacks to single column on mobile (≤768px)
- Social media icon links: GitHub, Twitter/X, Discord
- Footer navigation links (How It Works, Economics, Fairness, Security, Audit Contract)
- Resources column (Open Source Contract, Documentation, Fairness Proof)
- Disclaimer and legal text in bottom bar
- Terms of Service and Privacy Policy legal links
- Dynamic copyright year
- All interactive elements have \`focus-visible\` states for keyboard accessibility" --base main --head create-footer-component
bash: gh: command not found
GitHub CLI isn't installed. The branch is pushed — you can open the PR directly at:

https://github.com/Coredevjay/Tossd/pull/new/create-footer-component

Use this as the PR description:

Title: feat: Create Footer component (#301)

Body:

Closes #301

Builds the site footer with navigation links, social media icons, and legal/disclaimer text.

## Changes
- `Footer.tsx` — brand column, navigation column, resources column
- `Footer.module.css` — styled with design tokens from tossd.tokens.css

## Features
- Multi-column layout on desktop (2fr brand + 1fr nav + 1fr resources)
- Stacks to single column on mobile (≤768px)
- Social media icon links: GitHub, Twitter/X, Discord
- Footer nav links matching site sections
- Disclaimer + legal text in bottom bar
- Terms of Service and Privacy Policy links
- Dynamic copyright year
- focus-visible states on all interactive elem