### PR TITLE
feat: create CoinFlip animation component (#304)

### DIFF
--- a/frontend/components/CoinFlip.module.css
+++ b/frontend/components/CoinFlip.module.css
@@ -1,0 +1,123 @@
+/* ─── Scene ─────────────────────────────────────────────────────────────── */
+.scene {
+  width: 120px;
+  height: 120px;
+  perspective: 600px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* ─── Coin (3D container) ────────────────────────────────────────────────── */
+.coin {
+  width: 120px;
+  height: 120px;
+  position: relative;
+  transform-style: preserve-3d;
+  /* Default idle: show heads */
+  transform: rotateY(0deg);
+  transition: transform var(--motion-slow) var(--ease-standard);
+}
+
+/* ─── Faces ──────────────────────────────────────────────────────────────── */
+.face {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-1);
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+  user-select: none;
+}
+
+.faceSymbol {
+  font-family: var(--font-display);
+  font-size: 2.5rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.faceLabel {
+  font-family: var(--font-body);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+/* Heads — brand accent */
+.heads {
+  background: var(--color-brand-accent);
+  color: var(--color-bg-surface);
+  transform: rotateY(0deg);
+  box-shadow: inset 0 -4px 0 rgba(0, 0, 0, 0.15),
+    0 4px 20px rgba(15, 118, 110, 0.35);
+}
+
+/* Tails — brand ink */
+.tails {
+  background: var(--color-brand-ink);
+  color: var(--color-bg-surface);
+  transform: rotateY(180deg);
+  box-shadow: inset 0 -4px 0 rgba(0, 0, 0, 0.25),
+    0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+/* ─── Revealed states ────────────────────────────────────────────────────── */
+.showHeads {
+  transform: rotateY(0deg);
+}
+
+.showTails {
+  transform: rotateY(180deg);
+}
+
+/* ─── Flip animation ─────────────────────────────────────────────────────── */
+@keyframes flip {
+  0%   { transform: rotateY(0deg); }
+  100% { transform: rotateY(1080deg); } /* 3 full rotations */
+}
+
+.flipping {
+  animation: flip 1200ms var(--ease-standard) forwards;
+}
+
+/* ─── Reduced motion ─────────────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .coin {
+    transition: none;
+  }
+
+  .flipping {
+    /* Skip animation — jump straight to result via opacity pulse */
+    animation: none;
+  }
+
+  /* Instant reveal with a subtle fade instead of spin */
+  @keyframes fadeReveal {
+    0%   { opacity: 0; transform: scale(0.9); }
+    100% { opacity: 1; transform: scale(1); }
+  }
+
+  .showHeads,
+  .showTails {
+    animation: fadeReveal 300ms ease forwards;
+  }
+}
+
+/* ─── Accessibility ──────────────────────────────────────────────────────── */
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/frontend/components/CoinFlip.tsx
+++ b/frontend/components/CoinFlip.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from "react";
+import styles from "./CoinFlip.module.css";
+
+export type CoinFace = "heads" | "tails";
+export type CoinFlipState = "idle" | "flipping" | "revealed";
+
+interface CoinFlipProps {
+  result?: CoinFace;
+  state?: CoinFlipState;
+  onAnimationEnd?: () => void;
+}
+
+export function CoinFlip({
+  result = "heads",
+  state = "idle",
+  onAnimationEnd,
+}: CoinFlipProps) {
+  const [settled, setSettled] = useState(false);
+
+  useEffect(() => {
+    if (state === "flipping") {
+      setSettled(false);
+    }
+    if (state === "revealed") {
+      setSettled(true);
+    }
+  }, [state]);
+
+  const isFlipping = state === "flipping";
+  // When revealed: heads = 0deg (front face), tails = 180deg (back face)
+  const revealedRotation = settled
+    ? result === "heads"
+      ? styles.showHeads
+      : styles.showTails
+    : "";
+
+  return (
+    <div
+      className={styles.scene}
+      aria-label={
+        state === "revealed"
+          ? `Coin landed on ${result}`
+          : state === "flipping"
+          ? "Coin is flipping"
+          : "Coin"
+      }
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      <div
+        className={[
+          styles.coin,
+          isFlipping ? styles.flipping : "",
+          revealedRotation,
+        ]
+          .filter(Boolean)
+          .join(" ")}
+        onAnimationEnd={() => {
+          if (isFlipping) onAnimationEnd?.();
+        }}
+      >
+        {/* Heads face */}
+        <div className={`${styles.face} ${styles.heads}`} aria-hidden="true">
+          <span className={styles.faceSymbol}>H</span>
+          <span className={styles.faceLabel}>Heads</span>
+        </div>
+
+        {/* Tails face */}
+        <div className={`${styles.face} ${styles.tails}`} aria-hidden="true">
+          <span className={styles.faceSymbol}>T</span>
+          <span className={styles.faceLabel}>Tails</span>
+        </div>
+      </div>
+
+      {/* Screen-reader result announcement */}
+      {state === "revealed" && (
+        <p className={styles.srOnly}>Result: {result}</p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #304

## Changes
- `CoinFlip.tsx` — animated coin with idle/flipping/revealed states
- `CoinFlip.module.css` — 3D CSS transforms, keyframes, reduced-motion fallback

## Features
- 3D flip via rotateY + transform-style: preserve-3d + backface-visibility: hidden
- Flipping state: 1080deg spin (3 full rotations) over 1200ms
- Heads: brand accent green / Tails: brand ink black — clearly distinct faces
- Motion tokens used: --motion-slow, --ease-standard
- prefers-reduced-motion: animation replaced with a fade-scale reveal
- aria-live="polite" + sr-only result text for screen readers
- onAnimationEnd callback for parent coordination
