### PR TITLE
feat: add LoadingSpinner, Toast notification system, StatsDashboard, …

### DIFF
--- a/frontend/components/Grid.module.css
+++ b/frontend/components/Grid.module.css
@@ -1,0 +1,38 @@
+/* ── Grid container ─────────────────────────────────────────────────────── */
+.grid {
+  display: grid;
+  grid-template-columns: repeat(var(--grid-cols, 12), 1fr);
+  width: 100%;
+}
+
+/* ── Gap variants (spacing tokens) ─────────────────────────────────────── */
+.gap-none { gap: 0; }
+.gap-sm   { gap: var(--space-2, 8px); }
+.gap-md   { gap: var(--space-4, 16px); }
+.gap-lg   { gap: var(--space-6, 24px); }
+
+/* ── Grid item ──────────────────────────────────────────────────────────── */
+.item {
+  grid-column: span var(--item-span, 1);
+  min-width: 0; /* prevent blowout in nested grids */
+}
+
+/* ── Tablet (481 – 900 px) ──────────────────────────────────────────────── */
+@media (max-width: 900px) {
+  .grid {
+    grid-template-columns: repeat(var(--grid-cols-md, 6), 1fr);
+  }
+  .item {
+    grid-column: span var(--item-span-md, var(--item-span, 1));
+  }
+}
+
+/* ── Mobile (≤ 480 px) ──────────────────────────────────────────────────── */
+@media (max-width: 480px) {
+  .grid {
+    grid-template-columns: repeat(var(--grid-cols-sm, 4), 1fr);
+  }
+  .item {
+    grid-column: span var(--item-span-sm, var(--grid-cols-sm, 4));
+  }
+}

--- a/frontend/components/Grid.tsx
+++ b/frontend/components/Grid.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import styles from "./Grid.module.css";
+
+// ── Types ───────────────────────────────────────────────────────────────────
+type Cols = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+type Gap = "none" | "sm" | "md" | "lg";
+
+export interface GridProps {
+  /** Number of columns on desktop (≥ 901 px). Default 12. */
+  cols?: Cols;
+  /** Number of columns on tablet (481–900 px). Default half of `cols`, min 1. */
+  colsMd?: Cols;
+  /** Number of columns on mobile (≤ 480 px). Default 4. */
+  colsSm?: Cols;
+  /** Gap between cells using spacing tokens. Default "md". */
+  gap?: Gap;
+  as?: React.ElementType;
+  className?: string;
+  children?: React.ReactNode;
+}
+
+export interface GridItemProps {
+  /** Columns to span on desktop. Default 1. */
+  span?: Cols;
+  /** Columns to span on tablet. Falls back to `span`. */
+  spanMd?: Cols;
+  /** Columns to span on mobile. Falls back to full row. */
+  spanSm?: Cols;
+  as?: React.ElementType;
+  className?: string;
+  children?: React.ReactNode;
+}
+
+// ── Grid ────────────────────────────────────────────────────────────────────
+export function Grid({
+  cols = 12,
+  colsMd,
+  colsSm = 4,
+  gap = "md",
+  as: Tag = "div",
+  className,
+  children,
+}: GridProps) {
+  const resolvedMd = colsMd ?? (Math.max(1, Math.floor(cols / 2)) as Cols);
+
+  return (
+    <Tag
+      className={[styles.grid, styles[`gap-${gap}`], className].filter(Boolean).join(" ")}
+      style={
+        {
+          "--grid-cols": cols,
+          "--grid-cols-md": resolvedMd,
+          "--grid-cols-sm": colsSm,
+        } as React.CSSProperties
+      }
+    >
+      {children}
+    </Tag>
+  );
+}
+
+// ── GridItem ─────────────────────────────────────────────────────────────────
+export function GridItem({
+  span = 1,
+  spanMd,
+  spanSm,
+  as: Tag = "div",
+  className,
+  children,
+}: GridItemProps) {
+  return (
+    <Tag
+      className={[styles.item, className].filter(Boolean).join(" ")}
+      style={
+        {
+          "--item-span": span,
+          "--item-span-md": spanMd ?? span,
+          "--item-span-sm": spanSm ?? "var(--grid-cols-sm)", // full row on mobile by default
+        } as React.CSSProperties
+      }
+    >
+      {children}
+    </Tag>
+  );
+}

--- a/frontend/components/LoadingSpinner.module.css
+++ b/frontend/components/LoadingSpinner.module.css
@@ -1,0 +1,77 @@
+/* ── Keyframes ─────────────────────────────────────────────────────────── */
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%       { opacity: 0.4; transform: scale(0.75); }
+}
+
+/* ── Root ──────────────────────────────────────────────────────────────── */
+.root {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+/* ── Size variants ─────────────────────────────────────────────────────── */
+.small  { width: 16px; height: 16px; }
+.medium { width: 28px; height: 28px; }
+.large  { width: 44px; height: 44px; }
+
+/* ── Spinning ring ─────────────────────────────────────────────────────── */
+.ring {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  border: 2px solid var(--color-brand-accent-soft);
+  border-top-color: var(--color-brand-accent);
+  animation: spin var(--motion-slow, 420ms) linear infinite;
+}
+
+.large .ring { border-width: 3px; }
+
+/* ── Pulsing dot (reduced-motion fallback) ─────────────────────────────── */
+.dot {
+  display: none;
+  width: 40%;
+  height: 40%;
+  border-radius: 50%;
+  background: var(--color-brand-accent);
+}
+
+/* ── Reduced-motion: swap ring → dot ───────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .ring { display: none; }
+  .dot  {
+    display: block;
+    animation: pulse 1.4s ease-in-out infinite;
+  }
+}
+
+/* ── Overlay mode ──────────────────────────────────────────────────────── */
+.overlayBackdrop {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(247, 246, 243, 0.75); /* --color-bg-base at 75% */
+  z-index: 50;
+}
+
+/* ── Screen-reader only ────────────────────────────────────────────────── */
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/frontend/components/LoadingSpinner.tsx
+++ b/frontend/components/LoadingSpinner.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import styles from "./LoadingSpinner.module.css";
+
+export type SpinnerSize = "small" | "medium" | "large";
+export type SpinnerMode = "inline" | "overlay";
+
+export interface LoadingSpinnerProps {
+  size?: SpinnerSize;
+  mode?: SpinnerMode;
+  label?: string;
+  className?: string;
+}
+
+export function LoadingSpinner({
+  size = "medium",
+  mode = "inline",
+  label = "Loading…",
+  className,
+}: LoadingSpinnerProps) {
+  const sizeClass = styles[size];
+  const modeClass = mode === "overlay" ? styles.overlay : styles.inline;
+
+  const spinner = (
+    <span
+      role="status"
+      aria-label={label}
+      className={[styles.root, sizeClass, className ?? ""].filter(Boolean).join(" ")}
+    >
+      {/* Visible to screen readers only */}
+      <span className={styles.srOnly}>{label}</span>
+      {/* Spinning ring — hidden in reduced-motion via CSS */}
+      <span className={styles.ring} aria-hidden="true" />
+      {/* Pulsing dot — shown only in reduced-motion via CSS */}
+      <span className={styles.dot} aria-hidden="true" />
+    </span>
+  );
+
+  if (mode === "overlay") {
+    return (
+      <div className={[styles.overlayBackdrop, className ?? ""].filter(Boolean).join(" ")}>
+        {spinner}
+      </div>
+    );
+  }
+
+  return spinner;
+}

--- a/frontend/components/StatsDashboard.module.css
+++ b/frontend/components/StatsDashboard.module.css
@@ -1,0 +1,169 @@
+/* ── Section ────────────────────────────────────────────────────────────── */
+.section {
+  padding: var(--space-8) var(--space-6);
+  background: var(--color-bg-base);
+}
+
+/* ── Header row ─────────────────────────────────────────────────────────── */
+.header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  margin-bottom: var(--space-6);
+  flex-wrap: wrap;
+}
+
+.heading {
+  font-family: var(--font-display);
+  font-size: var(--font-size-h2);
+  font-weight: 700;
+  color: var(--color-fg-primary);
+  margin: 0;
+  line-height: var(--line-height-tight);
+  flex: 1;
+}
+
+.meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-shrink: 0;
+}
+
+.timestamp {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--color-fg-muted);
+}
+
+.errorBadge {
+  font-family: var(--font-body);
+  font-size: var(--font-size-xs);
+  color: var(--color-state-danger);
+  background: color-mix(in srgb, var(--color-state-danger) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-state-danger) 25%, transparent);
+  border-radius: var(--radius-pill);
+  padding: 2px var(--space-2);
+}
+
+.refreshBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-surface);
+  color: var(--color-fg-muted);
+  cursor: pointer;
+  transition: color var(--motion-fast), background var(--motion-fast);
+}
+
+.refreshBtn:hover {
+  color: var(--color-fg-primary);
+  background: var(--color-bg-subtle);
+}
+
+.refreshBtn:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 1px;
+}
+
+/* ── Stat grid ──────────────────────────────────────────────────────────── */
+.grid,
+.loadingGrid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-4);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+/* ── Stat card ──────────────────────────────────────────────────────────── */
+.card {
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.label {
+  font-family: var(--font-body);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-fg-muted);
+  margin: 0;
+}
+
+.valueRow {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-1);
+  margin: 0;
+}
+
+.value {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-h3);
+  font-weight: 600;
+  color: var(--color-fg-primary);
+  line-height: var(--line-height-tight);
+}
+
+.unit {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  color: var(--color-fg-muted);
+}
+
+.description {
+  font-family: var(--font-body);
+  font-size: var(--font-size-xs);
+  color: var(--color-fg-muted);
+  margin: 0;
+  line-height: var(--line-height-normal);
+}
+
+/* ── Loading skeleton ───────────────────────────────────────────────────── */
+@keyframes shimmer {
+  from { background-position: -200% 0; }
+  to   { background-position:  200% 0; }
+}
+
+.skeleton {
+  height: 110px;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(
+    90deg,
+    var(--color-bg-subtle) 25%,
+    var(--color-bg-surface) 50%,
+    var(--color-bg-subtle) 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.4s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton { animation: none; background: var(--color-bg-subtle); }
+}
+
+/* ── Responsive ─────────────────────────────────────────────────────────── */
+@media (max-width: 900px) {
+  .grid,
+  .loadingGrid { grid-template-columns: repeat(2, 1fr); }
+}
+
+@media (max-width: 480px) {
+  .section { padding: var(--space-6) var(--space-4); }
+  .grid,
+  .loadingGrid { grid-template-columns: 1fr; }
+}

--- a/frontend/components/StatsDashboard.tsx
+++ b/frontend/components/StatsDashboard.tsx
@@ -1,0 +1,150 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { ContractStats, formatGames, stroopsToXlm } from "./statsUtils";
+import { LoadingSpinner } from "./LoadingSpinner";
+import styles from "./StatsDashboard.module.css";
+
+// ── Stat card ───────────────────────────────────────────────────────────────
+interface StatCardProps {
+  label: string;
+  value: string;
+  unit?: string;
+  description?: string;
+}
+
+function StatCard({ label, value, unit, description }: StatCardProps) {
+  return (
+    <div className={styles.card}>
+      <dt className={styles.label}>{label}</dt>
+      <dd className={styles.valueRow}>
+        <span className={styles.value}>{value}</span>
+        {unit && <span className={styles.unit}>{unit}</span>}
+      </dd>
+      {description && <p className={styles.description}>{description}</p>}
+    </div>
+  );
+}
+
+// ── Dashboard ───────────────────────────────────────────────────────────────
+export interface StatsDashboardProps {
+  /**
+   * Async function that fetches current stats from the contract.
+   * Swap this out for your actual Soroban RPC call.
+   */
+  fetchStats: () => Promise<ContractStats>;
+  /** Poll interval in ms. Default 15 000. Pass 0 to disable polling. */
+  pollInterval?: number;
+}
+
+type Status = "idle" | "loading" | "success" | "error";
+
+export function StatsDashboard({ fetchStats, pollInterval = 15_000 }: StatsDashboardProps) {
+  const [stats, setStats] = useState<ContractStats | null>(null);
+  const [status, setStatus] = useState<Status>("idle");
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const load = useCallback(async () => {
+    setStatus((s) => (s === "idle" ? "loading" : s));
+    try {
+      const data = await fetchStats();
+      setStats(data);
+      setLastUpdated(new Date());
+      setStatus("success");
+    } catch {
+      setStatus("error");
+    }
+  }, [fetchStats]);
+
+  useEffect(() => {
+    load();
+    if (pollInterval > 0) {
+      intervalRef.current = setInterval(load, pollInterval);
+    }
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [load, pollInterval]);
+
+  const cards = stats
+    ? [
+        {
+          label: "Total Games",
+          value: formatGames(stats.total_games),
+          description: "Cumulative games started on-chain",
+        },
+        {
+          label: "Total Volume",
+          value: stroopsToXlm(stats.total_volume),
+          unit: "XLM",
+          description: "Cumulative XLM wagered",
+        },
+        {
+          label: "Fees Collected",
+          value: stroopsToXlm(stats.total_fees),
+          unit: "XLM",
+          description: "Protocol rake accumulated",
+        },
+        {
+          label: "Reserve Balance",
+          value: stroopsToXlm(stats.reserve_balance),
+          unit: "XLM",
+          description: "Current contract solvency reserve",
+        },
+      ]
+    : [];
+
+  return (
+    <section className={styles.section} aria-labelledby="stats-heading" aria-live="polite">
+      <div className={styles.header}>
+        <h2 id="stats-heading" className={styles.heading}>
+          Contract Stats
+        </h2>
+        <div className={styles.meta}>
+          {status === "loading" && stats === null && (
+            <LoadingSpinner size="small" label="Loading stats…" />
+          )}
+          {status === "error" && (
+            <span className={styles.errorBadge} role="alert">
+              Failed to load
+            </span>
+          )}
+          {lastUpdated && (
+            <span className={styles.timestamp}>
+              Updated{" "}
+              <time dateTime={lastUpdated.toISOString()}>
+                {lastUpdated.toLocaleTimeString()}
+              </time>
+            </span>
+          )}
+          {pollInterval > 0 && (
+            <button className={styles.refreshBtn} onClick={load} aria-label="Refresh stats">
+              <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+                <path
+                  d="M12.5 2.5A6 6 0 1 1 7 1"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                />
+                <path d="M7 1l2 2-2 2" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            </button>
+          )}
+        </div>
+      </div>
+
+      {status === "loading" && stats === null ? (
+        <div className={styles.loadingGrid}>
+          {[0, 1, 2, 3].map((i) => (
+            <div key={i} className={styles.skeleton} aria-hidden="true" />
+          ))}
+        </div>
+      ) : (
+        <dl className={styles.grid}>
+          {cards.map((c) => (
+            <StatCard key={c.label} {...c} />
+          ))}
+        </dl>
+      )}
+    </section>
+  );
+}

--- a/frontend/components/Toast.module.css
+++ b/frontend/components/Toast.module.css
@@ -1,0 +1,110 @@
+/* ── Enter / exit animations ───────────────────────────────────────────── */
+@keyframes slideIn {
+  from { opacity: 0; transform: translateY(8px) scale(0.97); }
+  to   { opacity: 1; transform: translateY(0)   scale(1); }
+}
+
+@keyframes fadeOut {
+  to { opacity: 0; transform: translateY(4px) scale(0.97); }
+}
+
+/* ── Region (portal container) ─────────────────────────────────────────── */
+.region {
+  position: fixed;
+  bottom: var(--space-6, 24px);
+  right: var(--space-6, 24px);
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2, 8px);
+  width: min(360px, calc(100vw - 2 * var(--space-6, 24px)));
+  pointer-events: none;
+}
+
+/* ── Toast base ─────────────────────────────────────────────────────────── */
+.toast {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3, 12px);
+  padding: var(--space-3, 12px) var(--space-4, 16px);
+  border-radius: var(--radius-md, 10px);
+  background: var(--color-bg-surface, #fff);
+  box-shadow: var(--shadow-card, 0 8px 30px rgba(0,0,0,.08));
+  border-left: 3px solid transparent;
+  font-family: var(--font-body);
+  font-size: var(--font-size-sm, 0.875rem);
+  line-height: var(--line-height-normal, 1.5);
+  color: var(--color-fg-primary, #171717);
+  pointer-events: all;
+  animation: slideIn var(--motion-base, 220ms) var(--ease-standard, cubic-bezier(0.2,0.8,0.2,1)) both;
+}
+
+.exit {
+  animation: fadeOut var(--motion-base, 220ms) var(--ease-standard) forwards;
+}
+
+/* ── Type variants ──────────────────────────────────────────────────────── */
+.success { border-left-color: var(--color-state-success, #1D7A45); }
+.success .icon { color: var(--color-state-success, #1D7A45); }
+
+.error { border-left-color: var(--color-state-danger, #A12A2A); }
+.error .icon { color: var(--color-state-danger, #A12A2A); }
+
+.warning { border-left-color: var(--color-state-warning, #B5681D); }
+.warning .icon { color: var(--color-state-warning, #B5681D); }
+
+.info { border-left-color: var(--color-state-info, #1F5FAF); }
+.info .icon { color: var(--color-state-info, #1F5FAF); }
+
+/* ── Parts ──────────────────────────────────────────────────────────────── */
+.icon {
+  flex-shrink: 0;
+  margin-top: 1px; /* optical alignment with first text line */
+  display: flex;
+}
+
+.message {
+  flex: 1;
+}
+
+.dismiss {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--color-fg-muted, #757575);
+  cursor: pointer;
+  border-radius: var(--radius-sm, 6px);
+  transition: color var(--motion-fast, 140ms), background var(--motion-fast, 140ms);
+}
+
+.dismiss:hover {
+  color: var(--color-fg-primary, #171717);
+  background: var(--color-bg-subtle, #EFEDE8);
+}
+
+.dismiss:focus-visible {
+  outline: 2px solid var(--color-focus-ring, #0F766E);
+  outline-offset: 1px;
+}
+
+/* ── Reduced motion ─────────────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .toast, .exit { animation: none; }
+  .exit { opacity: 0; }
+}
+
+/* ── Mobile: full-width, bottom-anchored ────────────────────────────────── */
+@media (max-width: 480px) {
+  .region {
+    right: var(--space-4, 16px);
+    left: var(--space-4, 16px);
+    bottom: var(--space-4, 16px);
+    width: auto;
+  }
+}

--- a/frontend/components/ToastContext.ts
+++ b/frontend/components/ToastContext.ts
@@ -1,0 +1,23 @@
+import { createContext, useContext } from "react";
+
+export type ToastType = "success" | "error" | "info" | "warning";
+
+export interface Toast {
+  id: string;
+  type: ToastType;
+  message: string;
+  duration?: number; // ms; 0 = persist until dismissed
+}
+
+export interface ToastContextValue {
+  addToast: (toast: Omit<Toast, "id">) => void;
+  removeToast: (id: string) => void;
+}
+
+export const ToastContext = createContext<ToastContextValue | null>(null);
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error("useToast must be used inside <ToastProvider>");
+  return ctx;
+}

--- a/frontend/components/ToastProvider.tsx
+++ b/frontend/components/ToastProvider.tsx
@@ -1,0 +1,109 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { Toast, ToastContext, ToastContextValue, ToastType } from "./ToastContext";
+import styles from "./Toast.module.css";
+
+const DEFAULT_DURATION = 5000;
+
+// ── Icons (inline SVG, no external dep) ────────────────────────────────────
+const ICONS: Record<ToastType, React.ReactNode> = {
+  success: (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <circle cx="8" cy="8" r="7" stroke="currentColor" strokeWidth="1.5" />
+      <path d="M5 8l2 2 4-4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  ),
+  error: (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <circle cx="8" cy="8" r="7" stroke="currentColor" strokeWidth="1.5" />
+      <path d="M5.5 5.5l5 5M10.5 5.5l-5 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  ),
+  warning: (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path d="M8 2L14.5 13.5H1.5L8 2z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+      <path d="M8 6.5v3M8 11h.01" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  ),
+  info: (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <circle cx="8" cy="8" r="7" stroke="currentColor" strokeWidth="1.5" />
+      <path d="M8 7v4M8 5h.01" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  ),
+};
+
+// ── Single toast item ───────────────────────────────────────────────────────
+function ToastItem({ toast, onRemove }: { toast: Toast; onRemove: (id: string) => void }) {
+  const [exiting, setExiting] = useState(false);
+
+  const dismiss = useCallback(() => {
+    setExiting(true);
+    // Wait for exit animation before removing from DOM
+    setTimeout(() => onRemove(toast.id), 220);
+  }, [onRemove, toast.id]);
+
+  useEffect(() => {
+    const duration = toast.duration ?? DEFAULT_DURATION;
+    if (duration === 0) return;
+    const t = setTimeout(dismiss, duration);
+    return () => clearTimeout(t);
+  }, [dismiss, toast.duration]);
+
+  return (
+    <div
+      className={[styles.toast, styles[toast.type], exiting ? styles.exit : ""].filter(Boolean).join(" ")}
+      role="status"
+      aria-atomic="true"
+    >
+      <span className={styles.icon}>{ICONS[toast.type]}</span>
+      <span className={styles.message}>{toast.message}</span>
+      <button
+        className={styles.dismiss}
+        onClick={dismiss}
+        aria-label="Dismiss notification"
+      >
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+          <path d="M1 1l10 10M11 1L1 11" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+        </svg>
+      </button>
+    </div>
+  );
+}
+
+// ── Provider ────────────────────────────────────────────────────────────────
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const counterRef = useRef(0);
+
+  const addToast = useCallback((toast: Omit<Toast, "id">) => {
+    const id = `toast-${++counterRef.current}`;
+    setToasts((prev) => [...prev, { ...toast, id }]);
+  }, []);
+
+  const removeToast = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const value: ToastContextValue = { addToast, removeToast };
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      {typeof document !== "undefined" &&
+        createPortal(
+          <div
+            className={styles.region}
+            aria-live="polite"
+            aria-label="Notifications"
+            aria-relevant="additions"
+          >
+            {toasts.map((t) => (
+              <ToastItem key={t.id} toast={t} onRemove={removeToast} />
+            ))}
+          </div>,
+          document.body
+        )}
+    </ToastContext.Provider>
+  );
+}

--- a/frontend/components/statsUtils.ts
+++ b/frontend/components/statsUtils.ts
@@ -1,0 +1,23 @@
+/** Shape returned by the contract's `get_stats()` function. */
+export interface ContractStats {
+  total_games: number;
+  /** Cumulative XLM wagered, in stroops (1 XLM = 10_000_000 stroops). */
+  total_volume: bigint;
+  /** Cumulative protocol fees collected, in stroops. */
+  total_fees: bigint;
+  /** Current reserve balance, in stroops. */
+  reserve_balance: bigint;
+}
+
+const STROOPS_PER_XLM = 10_000_000n;
+
+export function stroopsToXlm(stroops: bigint): string {
+  const whole = stroops / STROOPS_PER_XLM;
+  const frac = stroops % STROOPS_PER_XLM;
+  const fracStr = frac.toString().padStart(7, "0").replace(/0+$/, "") || "0";
+  return `${whole.toLocaleString()}.${fracStr}`;
+}
+
+export function formatGames(n: number): string {
+  return n.toLocaleString();
+}


### PR DESCRIPTION

feat: add LoadingSpinner, Toast notification system, StatsDashboard, and responsive Grid 
components

This PR implements four foundational UI components for the Tossd frontend, establishing 
reusable building blocks for loading states, notifications, data display, and layout.

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


Changes

- **LoadingSpinner** (#309) — Reusable spinner with small/medium/large size variants, 
inline/overlay modes, brand accent color, and a pulsing-dot fallback for 
prefers-reduced-motion.

- **Toast notification system** (#310) — ToastProvider + useToast hook with a notification 
queue, success/error/warning/info types, configurable auto-dismiss timeout, manual dismiss, 
and an aria-live region for screen reader announcements.

- **StatsDashboard** (#311) — Displays total_games, total_volume, total_fees, and 
reserve_balance from the contract's get_stats(). All numbers rendered in monospace, with 
shimmer skeleton loading states, configurable polling interval, and error recovery.

- **Responsive Grid system** (#312) — Grid and GridItem components backed by CSS custom 
properties. Supports 12-column desktop, configurable tablet, and 4-column mobile layouts with 
gap utilities mapped to spacing tokens and full nested grid support.

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


Testing checklist
- [ ] LoadingSpinner renders all three sizes in inline and overlay modes
- [ ] Reduced-motion fallback shows pulsing dot (no rotation)
- [ ] Toast queue stacks multiple notifications correctly
- [ ] Auto-dismiss fires at configured timeout; duration: 0 persists
- [ ] StatsDashboard polls and updates without blanking stale data
- [ ] All stat values render in monospace; XLM conversion is correct
- [ ] Grid collapses correctly at 900 px and 480 px breakpoints
- [ ] Nested grids render without content blowout

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


Closes #309
Closes #310
Closes #311
Closes #312