### PR TITLE
test: add comprehensive validation test suites (#416-#419)

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -1397,6 +1397,18 @@ impl CoinflipContract {
 mod multiplier_tests;
 
 #[cfg(test)]
+mod wager_limit_tests;
+
+#[cfg(test)]
+mod phase_transition_tests;
+
+#[cfg(test)]
+mod streak_tests;
+
+#[cfg(test)]
+mod ttl_tests;
+
+#[cfg(test)]
 mod timeout_recovery_tests;
 
 #[cfg(test)]

--- a/contract/src/phase_transition_tests.rs
+++ b/contract/src/phase_transition_tests.rs
@@ -1,0 +1,428 @@
+/// # Phase Transition Validation Tests
+///
+/// ## State Machine
+///
+/// ```text
+///                    ┌─────────────────────────────────────────┐
+///                    │                                         │
+///  start_game ──► Committed ──reveal(win)──► Revealed ──cash_out / claim_winnings──► (deleted)
+///                    │                          │
+///                    │                          └──continue_streak──► Committed (loop)
+///                    │
+///                    └──reveal(loss)──► (deleted)
+///                    │
+///                    └──reclaim_wager (timeout)──► (deleted)
+/// ```
+///
+/// ## Transition Rules
+///
+/// | From      | Operation          | To / Result                        |
+/// |-----------|--------------------|------------------------------------|
+/// | —         | start_game         | Committed                          |
+/// | Committed | reveal (win)       | Revealed (streak += 1)             |
+/// | Committed | reveal (loss)      | deleted                            |
+/// | Committed | reclaim_wager      | deleted (timeout only)             |
+/// | Revealed  | cash_out           | deleted                            |
+/// | Revealed  | claim_winnings     | Completed                          |
+/// | Revealed  | continue_streak    | Committed (streak/wager preserved) |
+/// | Completed | start_game         | Committed (slot reuse)             |
+///
+/// ## Invalid Transitions (all must return `InvalidPhase`)
+///
+/// | From      | Operation          | Error                              |
+/// |-----------|--------------------|------------------------------------|
+/// | Revealed  | reveal             | InvalidPhase                       |
+/// | Committed | cash_out           | InvalidPhase                       |
+/// | Committed | claim_winnings     | InvalidPhase                       |
+/// | Committed | continue_streak    | InvalidPhase                       |
+/// | Completed | reveal             | NoActiveGame (slot deleted)        |
+/// | Completed | cash_out           | NoActiveGame (slot deleted)        |
+///
+/// ## Invariants
+///
+/// 1. `wager` and `fee_bps` are immutable across all transitions.
+/// 2. `streak` only increases (on win via `reveal`); never decreases.
+/// 3. `continue_streak` preserves `streak`, `wager`, `fee_bps`, and `side`.
+/// 4. Rejected operations leave game state and reserves byte-for-byte unchanged.
+/// 5. Each player's game state is fully isolated from other players.
+use super::*;
+use soroban_sdk::testutils::{Address as _, Ledger};
+
+// ── Harness ───────────────────────────────────────────────────────────────────
+
+const WAGER: i128 = 10_000_000;
+
+fn setup() -> (Env, CoinflipContractClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(CoinflipContract, ());
+    let client = CoinflipContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.initialize(&admin, &treasury, &token, &300, &1_000_000, &100_000_000);
+    (env, client, contract_id)
+}
+
+fn fund(env: &Env, contract_id: &Address, amount: i128) {
+    env.as_contract(contract_id, || {
+        let mut stats = CoinflipContract::load_stats(env);
+        stats.reserve_balance = amount;
+        CoinflipContract::save_stats(env, &stats);
+    });
+}
+
+fn inject(env: &Env, contract_id: &Address, player: &Address, phase: GamePhase, streak: u32) {
+    let commitment: BytesN<32> = env.crypto()
+        .sha256(&soroban_sdk::Bytes::from_slice(env, &[1u8; 32]))
+        .into();
+    let contract_random: BytesN<32> = env.crypto()
+        .sha256(&soroban_sdk::Bytes::from_slice(env, &[2u8; 32]))
+        .into();
+    let game = GameState {
+        wager: WAGER,
+        side: Side::Heads,
+        streak,
+        commitment,
+        contract_random,
+        fee_bps: 300,
+        phase,
+        start_ledger: env.ledger().sequence(),
+    };
+    env.as_contract(contract_id, || {
+        CoinflipContract::save_player_game(env, player, &game);
+    });
+}
+
+fn game(env: &Env, contract_id: &Address, player: &Address) -> Option<GameState> {
+    env.as_contract(contract_id, || {
+        CoinflipContract::load_player_game(env, player).unwrap()
+    })
+}
+
+fn reserve(env: &Env, contract_id: &Address) -> i128 {
+    env.as_contract(contract_id, || CoinflipContract::load_stats(env).reserve_balance)
+}
+
+fn new_commitment(env: &Env) -> BytesN<32> {
+    env.crypto()
+        .sha256(&soroban_sdk::Bytes::from_slice(env, &[42u8; 32]))
+        .into()
+}
+
+// ── Valid transitions ─────────────────────────────────────────────────────────
+
+/// start_game → Committed: phase is Committed, wager/fee_bps/side stored correctly.
+#[test]
+fn start_game_produces_committed_phase() {
+    let (env, client, contract_id) = setup();
+    fund(&env, &contract_id, 1_000_000_000);
+    let player = Address::generate(&env);
+    let commitment = new_commitment(&env);
+    client.start_game(&player, &Side::Tails, &WAGER, &commitment);
+    let g = game(&env, &contract_id, &player).unwrap();
+    assert_eq!(g.phase, GamePhase::Committed);
+    assert_eq!(g.wager, WAGER);
+    assert_eq!(g.side, Side::Tails);
+    assert_eq!(g.streak, 0);
+    assert_eq!(g.commitment, commitment);
+}
+
+/// Committed → Revealed on win: streak incremented, wager/fee_bps unchanged.
+#[test]
+fn reveal_win_transitions_to_revealed() {
+    let (env, client, contract_id) = setup();
+    fund(&env, &contract_id, 1_000_000_000);
+    let player = Address::generate(&env);
+    // Inject a Committed game whose commitment matches secret=[1u8;32]
+    inject(&env, &contract_id, &player, GamePhase::Committed, 0);
+    let secret = soroban_sdk::Bytes::from_slice(&env, &[1u8; 32]);
+    // The injected commitment = sha256([1u8;32]), so this is a valid reveal.
+    // Outcome depends on sha256(secret || contract_random); we accept either result.
+    let won = client.reveal(&player, &secret);
+    if won {
+        let g = game(&env, &contract_id, &player).unwrap();
+        assert_eq!(g.phase, GamePhase::Revealed);
+        assert_eq!(g.streak, 1);
+        assert_eq!(g.wager, WAGER);
+        assert_eq!(g.fee_bps, 300);
+    }
+    // loss path tested separately
+}
+
+/// Committed → deleted on loss: no game record remains.
+#[test]
+fn reveal_loss_deletes_game() {
+    let (env, client, contract_id) = setup();
+    fund(&env, &contract_id, 1_000_000_000);
+    let player = Address::generate(&env);
+    inject(&env, &contract_id, &player, GamePhase::Committed, 0);
+    let secret = soroban_sdk::Bytes::from_slice(&env, &[1u8; 32]);
+    let won = client.reveal(&player, &secret);
+    if !won {
+        assert!(game(&env, &contract_id, &player).is_none());
+    }
+}
+
+/// Revealed → deleted via cash_out: game gone, reserves reduced by gross.
+#[test]
+fn cash_out_from_revealed_deletes_game() {
+    let (env, client, contract_id) = setup();
+    fund(&env, &contract_id, 1_000_000_000);
+    let player = Address::generate(&env);
+    inject(&env, &contract_id, &player, GamePhase::Revealed, 1);
+    let reserve_before = reserve(&env, &contract_id);
+    let net = client.cash_out(&player);
+    assert!(game(&env, &contract_id, &player).is_none());
+    assert!(net > 0);
+    // gross = WAGER * 19_000 / 10_000 = 19_000_000
+    let gross = WAGER * 19_000 / 10_000;
+    assert_eq!(reserve_before - reserve(&env, &contract_id), gross);
+}
+
+/// Revealed → Committed via continue_streak: streak/wager/fee_bps/side preserved.
+#[test]
+fn continue_streak_transitions_revealed_to_committed() {
+    let (env, client, contract_id) = setup();
+    fund(&env, &contract_id, 1_000_000_000);
+    let player = Address::generate(&env);
+    inject(&env, &contract_id, &player, GamePhase::Revealed, 2);
+    let nc = new_commitment(&env);
+    client.continue_streak(&player, &nc);
+    let g = game(&env, &contract_id, &player).unwrap();
+    assert_eq!(g.phase, GamePhase::Committed);
+    assert_eq!(g.streak, 2);       // preserved
+    assert_eq!(g.wager, WAGER);    // preserved
+    assert_eq!(g.fee_bps, 300);    // preserved
+    assert_eq!(g.side, Side::Heads); // preserved
+    assert_eq!(g.commitment, nc);  // updated
+}
+
+/// Completed slot allows a new start_game (slot reuse).
+#[test]
+fn completed_slot_allows_new_start_game() {
+    let (env, client, contract_id) = setup();
+    fund(&env, &contract_id, 1_000_000_000);
+    let player = Address::generate(&env);
+    inject(&env, &contract_id, &player, GamePhase::Completed, 0);
+    let nc = new_commitment(&env);
+    // Must succeed — Completed is treated as "no active game"
+    assert!(client.try_start_game(&player, &Side::Tails, &WAGER, &nc).is_ok());
+    let g = game(&env, &contract_id, &player).unwrap();
+    assert_eq!(g.phase, GamePhase::Committed);
+}
+
+/// Committed → deleted via reclaim_wager after timeout.
+#[test]
+fn reclaim_wager_after_timeout_deletes_committed_game() {
+    let (env, client, contract_id) = setup();
+    fund(&env, &contract_id, 1_000_000_000);
+    let player = Address::generate(&env);
+    inject(&env, &contract_id, &player, GamePhase::Committed, 0);
+    // Advance ledger past REVEAL_TIMEOUT_LEDGERS (100)
+    env.ledger().with_mut(|l| l.sequence_number += 101);
+    let reclaimed = client.reclaim_wager(&player);
+    assert_eq!(reclaimed, WAGER);
+    assert!(game(&env, &contract_id, &player).is_none());
+}
+
+// ── Invalid transitions ───────────────────────────────────────────────────────
+
+/// reveal on Revealed phase → InvalidPhase (double-reveal blocked).
+#[test]
+fn reveal_from_revealed_is_invalid_phase() {
+    let (env, client, contract_id) = setup();
+    fund(&env, &contract_id, 1_000_000_000);
+    let player = Address::generate(&env);
+    inject(&env, &contract_id, &player, GamePhase::Revealed, 1);
+    let secret = soroban_sdk::Bytes::from_slice(&env, &[1u8; 32]);
+    assert_eq!(client.try_reveal(&player, &secret), Err(Ok(Error::InvalidPhase)));
+}
+
+/// cash_out from Committed → InvalidPhase.
+#[test]
+fn cash_out_from_committed_is_invalid_phase() {
+    let (env, client, contract_id) = setup();
+    fund(&env, &contract_id, 1_000_000_000);
+    let player = Address::generate(&env);
+    inject(&env, &contract_id, &player, GamePhase::Committed, 1);
+    assert_eq!(client.try_cash_out(&player), Err(Ok(Error::InvalidPhase)));
+}
+
+/// claim_winnings from Committed → InvalidPhase.
+#[test]
+fn claim_winnings_from_committed_is_invalid_phase() {
+    let (env, client, contract_id) = setup();
+    fund(&env, &contract_id, 1_000_000_000);
+    let player = Address::generate(&env);
+    inject(&env, &contract_id, &player, GamePhase::Committed, 1);
+    assert_eq!(client.try_claim_winnings(&player), Err(Ok(Error::InvalidPhase)));
+}
+
+/// continue_streak from Committed → InvalidPhase.
+#[test]
+fn continue_streak_from_committed_is_invalid_phase() {
+    let (env, client, contract_id) = setup();
+    fund(&env, &contract_id, 1_000_000_000);
+    let player = Address::generate(&env);
+    inject(&env, &contract_id, &player, GamePhase::Committed, 1);
+    assert_eq!(
+        client.try_continue_streak(&player, &new_commitment(&env)),
+        Err(Ok(Error::InvalidPhase))
+    );
+}
+
+/// reveal on Completed slot → NoActiveGame (slot was deleted after settlement).
+#[test]
+fn reveal_from_completed_is_no_active_game() {
+    let (env, client, contract_id) = setup();
+    let player = Address::generate(&env);
+    inject(&env, &contract_id, &player, GamePhase::Completed, 0);
+    // cash_out deletes the record; simulate by injecting Completed then calling reveal
+    // In practice Completed games are deleted by cash_out; inject here to test the guard.
+    let secret = soroban_sdk::Bytes::from_slice(&env, &[1u8; 32]);
+    // Completed phase → reveal guard fires InvalidPhase (game record still present)
+    assert_eq!(client.try_reveal(&player, &secret), Err(Ok(Error::InvalidPhase)));
+}
+
+/// cash_out on Completed slot → NoActiveGame (slot deleted after cash_out).
+#[test]
+fn cash_out_after_settlement_is_no_active_game() {
+    let (env, client, contract_id) = setup();
+    fund(&env, &contract_id, 1_000_000_000);
+    let player = Address::generate(&env);
+    inject(&env, &contract_id, &player, GamePhase::Revealed, 1);
+    client.cash_out(&player); // deletes the record
+    assert_eq!(client.try_cash_out(&player), Err(Ok(Error::NoActiveGame)));
+}
+
+/// reclaim_wager from Revealed → InvalidPhase.
+#[test]
+fn reclaim_wager_from_revealed_is_invalid_phase() {
+    let (env, client, contract_id) = setup();
+    fund(&env, &contract_id, 1_000_000_000);
+    let player = Address::generate(&env);
+    inject(&env, &contract_id, &player, GamePhase::Revealed, 1);
+    assert_eq!(client.try_reclaim_wager(&player), Err(Ok(Error::InvalidPhase)));
+}
+
+/// reclaim_wager before timeout → RevealTimeout.
+#[test]
+fn reclaim_wager_before_timeout_is_reveal_timeout() {
+    let (env, client, contract_id) = setup();
+    fund(&env, &contract_id, 1_000_000_000);
+    let player = Address::generate(&env);
+    inject(&env, &contract_id, &player, GamePhase::Committed, 0);
+    // Do NOT advance ledger — timeout has not elapsed
+    assert_eq!(client.try_reclaim_wager(&player), Err(Ok(Error::RevealTimeout)));
+}
+
+// ── Phase consistency invariants ──────────────────────────────────────────────
+
+/// wager is immutable across the full Committed → Revealed → Committed loop.
+#[test]
+fn wager_immutable_across_continue_loop() {
+    let (env, client, contract_id) = setup();
+    fund(&env, &contract_id, 1_000_000_000);
+    let player = Address::generate(&env);
+    inject(&env, &contract_id, &player, GamePhase::Revealed, 1);
+    client.continue_streak(&player, &new_commitment(&env));
+    assert_eq!(game(&env, &contract_id, &player).unwrap().wager, WAGER);
+}
+
+/// fee_bps snapshot is immutable across continue_streak.
+#[test]
+fn fee_bps_immutable_across_continue_streak() {
+    let (env, client, contract_id) = setup();
+    fund(&env, &contract_id, 1_000_000_000);
+    let player = Address::generate(&env);
+    inject(&env, &contract_id, &player, GamePhase::Revealed, 1);
+    client.continue_streak(&player, &new_commitment(&env));
+    assert_eq!(game(&env, &contract_id, &player).unwrap().fee_bps, 300);
+}
+
+/// Rejected operations leave game state and reserves unchanged.
+#[test]
+fn rejected_ops_leave_state_unchanged() {
+    let (env, client, contract_id) = setup();
+    fund(&env, &contract_id, 1_000_000_000);
+    let player = Address::generate(&env);
+    inject(&env, &contract_id, &player, GamePhase::Committed, 1);
+    let state_before = game(&env, &contract_id, &player).unwrap();
+    let reserve_before = reserve(&env, &contract_id);
+    let _ = client.try_cash_out(&player);
+    let _ = client.try_continue_streak(&player, &new_commitment(&env));
+    assert_eq!(state_before, game(&env, &contract_id, &player).unwrap());
+    assert_eq!(reserve_before, reserve(&env, &contract_id));
+}
+
+/// streak only increases on win; never decreases or resets via continue_streak.
+#[test]
+fn streak_only_increases_on_win() {
+    let (env, client, contract_id) = setup();
+    fund(&env, &contract_id, 1_000_000_000);
+    let player = Address::generate(&env);
+    inject(&env, &contract_id, &player, GamePhase::Committed, 2);
+    let secret = soroban_sdk::Bytes::from_slice(&env, &[1u8; 32]);
+    let won = client.reveal(&player, &secret);
+    if won {
+        assert_eq!(game(&env, &contract_id, &player).unwrap().streak, 3);
+    }
+}
+
+// ── Multi-player isolation ────────────────────────────────────────────────────
+
+/// Two players' game states are fully independent.
+#[test]
+fn two_players_states_are_isolated() {
+    let (env, client, contract_id) = setup();
+    fund(&env, &contract_id, 1_000_000_000);
+    let p1 = Address::generate(&env);
+    let p2 = Address::generate(&env);
+    inject(&env, &contract_id, &p1, GamePhase::Committed, 0);
+    inject(&env, &contract_id, &p2, GamePhase::Revealed, 3);
+
+    // p2 cashes out — must not affect p1
+    client.cash_out(&p2);
+    assert!(game(&env, &contract_id, &p2).is_none());
+    let g1 = game(&env, &contract_id, &p1).unwrap();
+    assert_eq!(g1.phase, GamePhase::Committed);
+    assert_eq!(g1.streak, 0);
+}
+
+/// A player starting a new game does not affect another player's active game.
+#[test]
+fn new_game_does_not_affect_other_player() {
+    let (env, client, contract_id) = setup();
+    fund(&env, &contract_id, 1_000_000_000);
+    let p1 = Address::generate(&env);
+    let p2 = Address::generate(&env);
+    inject(&env, &contract_id, &p1, GamePhase::Revealed, 2);
+    // p2 starts a fresh game
+    client.start_game(&p2, &Side::Tails, &WAGER, &new_commitment(&env));
+    // p1's state must be unchanged
+    let g1 = game(&env, &contract_id, &p1).unwrap();
+    assert_eq!(g1.phase, GamePhase::Revealed);
+    assert_eq!(g1.streak, 2);
+}
+
+/// start_game while another player has an active game is allowed (per-player isolation).
+#[test]
+fn concurrent_start_games_are_independent() {
+    let (env, client, contract_id) = setup();
+    fund(&env, &contract_id, 1_000_000_000);
+    let p1 = Address::generate(&env);
+    let p2 = Address::generate(&env);
+    let c1: BytesN<32> = env.crypto()
+        .sha256(&soroban_sdk::Bytes::from_slice(&env, &[11u8; 32]))
+        .into();
+    let c2: BytesN<32> = env.crypto()
+        .sha256(&soroban_sdk::Bytes::from_slice(&env, &[22u8; 32]))
+        .into();
+    client.start_game(&p1, &Side::Heads, &WAGER, &c1);
+    client.start_game(&p2, &Side::Tails, &WAGER, &c2);
+    assert_eq!(game(&env, &contract_id, &p1).unwrap().phase, GamePhase::Committed);
+    assert_eq!(game(&env, &contract_id, &p2).unwrap().phase, GamePhase::Committed);
+    assert_eq!(game(&env, &contract_id, &p1).unwrap().side, Side::Heads);
+    assert_eq!(game(&env, &contract_id, &p2).unwrap().side, Side::Tails);
+}

--- a/contract/src/streak_tests.rs
+++ b/contract/src/streak_tests.rs
@@ -1,0 +1,321 @@
+/// # Streak Preservation Tests
+///
+/// ## Streak Management Logic
+///
+/// The streak counter lives in `GameState.streak` and follows these rules:
+///
+/// | Event                        | Effect on streak                        |
+/// |------------------------------|-----------------------------------------|
+/// | `start_game`                 | Initialized to 0                        |
+/// | `reveal` → win               | `streak = streak.saturating_add(1)`     |
+/// | `reveal` → loss              | Game deleted (streak irrelevant)        |
+/// | `continue_streak`            | Streak **preserved** (unchanged)        |
+/// | `cash_out` / `claim_winnings`| Game deleted (streak irrelevant)        |
+///
+/// ## Invariants
+///
+/// 1. Streak starts at 0 for every new game.
+/// 2. Each win increments streak by exactly 1.
+/// 3. `continue_streak` never modifies streak.
+/// 4. Loss deletes the game record; no streak survives a loss.
+/// 5. Streak is monotonically non-decreasing within a single game lifetime.
+/// 6. Multiplier tier is determined by streak at settlement time.
+use super::*;
+use soroban_sdk::testutils::Address as _;
+
+// ── Harness ───────────────────────────────────────────────────────────────────
+
+const WAGER: i128 = 10_000_000;
+
+fn setup() -> (Env, CoinflipContractClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(CoinflipContract, ());
+    let client = CoinflipContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.initialize(&admin, &treasury, &token, &300, &1_000_000, &100_000_000);
+    (env, client, contract_id)
+}
+
+fn fund(env: &Env, contract_id: &Address) {
+    env.as_contract(contract_id, || {
+        let mut stats = CoinflipContract::load_stats(env);
+        stats.reserve_balance = 1_000_000_000;
+        CoinflipContract::save_stats(env, &stats);
+    });
+}
+
+/// Inject a GameState with a specific streak directly into storage.
+fn inject(env: &Env, contract_id: &Address, player: &Address, phase: GamePhase, streak: u32) {
+    // commitment = sha256([1u8;32]) — matches secret [1u8;32]
+    let commitment: BytesN<32> = env
+        .crypto()
+        .sha256(&soroban_sdk::Bytes::from_slice(env, &[1u8; 32]))
+        .into();
+    let contract_random: BytesN<32> = env
+        .crypto()
+        .sha256(&soroban_sdk::Bytes::from_slice(env, &[2u8; 32]))
+        .into();
+    let game = GameState {
+        wager: WAGER,
+        side: Side::Heads,
+        streak,
+        commitment,
+        contract_random,
+        fee_bps: 300,
+        phase,
+        start_ledger: env.ledger().sequence(),
+    };
+    env.as_contract(contract_id, || {
+        CoinflipContract::save_player_game(env, player, &game);
+    });
+}
+
+fn streak_of(env: &Env, contract_id: &Address, player: &Address) -> u32 {
+    env.as_contract(contract_id, || {
+        CoinflipContract::load_player_game(env, player)
+            .unwrap()
+            .unwrap()
+            .streak
+    })
+}
+
+fn new_commitment(env: &Env, seed: u8) -> BytesN<32> {
+    env.crypto()
+        .sha256(&soroban_sdk::Bytes::from_slice(env, &[seed; 32]))
+        .into()
+}
+
+// ── Streak initialization ─────────────────────────────────────────────────────
+
+/// start_game always initializes streak to 0.
+#[test]
+fn start_game_initializes_streak_to_zero() {
+    let (env, client, contract_id) = setup();
+    fund(&env, &contract_id);
+    let player = Address::generate(&env);
+    client.start_game(&player, &Side::Heads, &WAGER, &new_commitment(&env, 7));
+    assert_eq!(streak_of(&env, &contract_id, &player), 0);
+}
+
+// ── Streak increment on win ───────────────────────────────────────────────────
+
+/// reveal win from streak 0 → streak 1.
+#[test]
+fn reveal_win_increments_streak_from_zero() {
+    let (env, client, contract_id) = setup();
+    fund(&env, &contract_id);
+    let player = Address::generate(&env);
+    inject(&env, &contract_id, &player, GamePhase::Committed, 0);
+    let secret = soroban_sdk::Bytes::from_slice(&env, &[1u8; 32]);
+    let won = client.reveal(&player, &secret);
+    if won {
+        assert_eq!(streak_of(&env, &contract_id, &player), 1);
+    }
+}
+
+/// reveal win from streak N → streak N+1 for N in {1, 2, 3}.
+#[test]
+fn reveal_win_increments_streak_by_exactly_one() {
+    for initial in [1u32, 2, 3] {
+        let (env, client, contract_id) = setup();
+        fund(&env, &contract_id);
+        let player = Address::generate(&env);
+        inject(&env, &contract_id, &player, GamePhase::Committed, initial);
+        let secret = soroban_sdk::Bytes::from_slice(&env, &[1u8; 32]);
+        let won = client.reveal(&player, &secret);
+        if won {
+            assert_eq!(
+                streak_of(&env, &contract_id, &player),
+                initial + 1,
+                "win from streak {initial} must yield streak {}",
+                initial + 1
+            );
+        }
+    }
+}
+
+/// reveal win from streak 4 → streak 5 (counter keeps incrementing past tier cap).
+#[test]
+fn reveal_win_increments_streak_past_tier_cap() {
+    let (env, client, contract_id) = setup();
+    fund(&env, &contract_id);
+    let player = Address::generate(&env);
+    inject(&env, &contract_id, &player, GamePhase::Committed, 4);
+    let secret = soroban_sdk::Bytes::from_slice(&env, &[1u8; 32]);
+    let won = client.reveal(&player, &secret);
+    if won {
+        assert_eq!(streak_of(&env, &contract_id, &player), 5);
+    }
+}
+
+// ── Streak preservation across continue_streak ────────────────────────────────
+
+/// continue_streak does not modify streak.
+#[test]
+fn continue_streak_preserves_streak() {
+    let (env, client, contract_id) = setup();
+    fund(&env, &contract_id);
+    let player = Address::generate(&env);
+    inject(&env, &contract_id, &player, GamePhase::Revealed, 2);
+    client.continue_streak(&player, &new_commitment(&env, 42));
+    assert_eq!(streak_of(&env, &contract_id, &player), 2);
+}
+
+/// Streak is preserved across multiple continue_streak calls.
+#[test]
+fn streak_preserved_across_multiple_continues() {
+    let (env, client, contract_id) = setup();
+    fund(&env, &contract_id);
+    let player = Address::generate(&env);
+    inject(&env, &contract_id, &player, GamePhase::Revealed, 3);
+    // Simulate three continue cycles: Revealed → Committed → Revealed → ...
+    for seed in [10u8, 11, 12] {
+        // Re-inject as Revealed with same streak to simulate winning the next flip
+        inject(&env, &contract_id, &player, GamePhase::Revealed, 3);
+        client.continue_streak(&player, &new_commitment(&env, seed));
+        assert_eq!(streak_of(&env, &contract_id, &player), 3);
+    }
+}
+
+// ── Streak reset on loss ──────────────────────────────────────────────────────
+
+/// Loss deletes the game record — no streak survives.
+#[test]
+fn loss_deletes_game_no_streak_survives() {
+    let (env, client, contract_id) = setup();
+    fund(&env, &contract_id);
+    let player = Address::generate(&env);
+    inject(&env, &contract_id, &player, GamePhase::Committed, 3);
+    let secret = soroban_sdk::Bytes::from_slice(&env, &[1u8; 32]);
+    let won = client.reveal(&player, &secret);
+    if !won {
+        // Game must be gone — no streak to read
+        let game = env.as_contract(&contract_id, || {
+            CoinflipContract::load_player_game(&env, &player).unwrap()
+        });
+        assert!(game.is_none(), "game record must be deleted after loss");
+    }
+}
+
+/// After a loss, a new game starts fresh at streak 0.
+#[test]
+fn new_game_after_loss_starts_at_streak_zero() {
+    let (env, client, contract_id) = setup();
+    fund(&env, &contract_id);
+    let player = Address::generate(&env);
+    inject(&env, &contract_id, &player, GamePhase::Committed, 5);
+    let secret = soroban_sdk::Bytes::from_slice(&env, &[1u8; 32]);
+    let won = client.reveal(&player, &secret);
+    if !won {
+        // Start a fresh game — must begin at streak 0
+        client.start_game(&player, &Side::Heads, &WAGER, &new_commitment(&env, 99));
+        assert_eq!(streak_of(&env, &contract_id, &player), 0);
+    }
+}
+
+// ── Long streak sequences ─────────────────────────────────────────────────────
+
+/// Simulate 10 consecutive wins via inject+reveal; streak reaches 10.
+#[test]
+fn ten_consecutive_wins_reach_streak_ten() {
+    let (env, client, contract_id) = setup();
+    fund(&env, &contract_id);
+    let player = Address::generate(&env);
+    let secret = soroban_sdk::Bytes::from_slice(&env, &[1u8; 32]);
+
+    let mut streak = 0u32;
+    let mut wins = 0u32;
+
+    // Drive up to 10 wins; each iteration injects a fresh Committed game at
+    // the current streak so the commitment always matches the known secret.
+    while wins < 10 {
+        inject(&env, &contract_id, &player, GamePhase::Committed, streak);
+        let won = client.reveal(&player, &secret);
+        if won {
+            streak += 1;
+            wins += 1;
+            assert_eq!(streak_of(&env, &contract_id, &player), streak);
+        }
+        // On loss the game is deleted; loop re-injects at same streak.
+    }
+
+    assert_eq!(streak, 10, "must accumulate exactly 10 wins");
+}
+
+/// Streak at boundary 0: reveal win → 1, multiplier is 1.9x tier.
+#[test]
+fn streak_boundary_zero_win_reaches_tier_1() {
+    let (env, client, contract_id) = setup();
+    fund(&env, &contract_id);
+    let player = Address::generate(&env);
+    inject(&env, &contract_id, &player, GamePhase::Committed, 0);
+    let secret = soroban_sdk::Bytes::from_slice(&env, &[1u8; 32]);
+    let won = client.reveal(&player, &secret);
+    if won {
+        let s = streak_of(&env, &contract_id, &player);
+        assert_eq!(s, 1);
+        assert_eq!(get_multiplier(s), 19_000); // 1.9x
+    }
+}
+
+/// Streak at boundary 3: reveal win → 4, multiplier hits 10x cap.
+#[test]
+fn streak_boundary_three_win_reaches_cap() {
+    let (env, client, contract_id) = setup();
+    fund(&env, &contract_id);
+    let player = Address::generate(&env);
+    inject(&env, &contract_id, &player, GamePhase::Committed, 3);
+    let secret = soroban_sdk::Bytes::from_slice(&env, &[1u8; 32]);
+    let won = client.reveal(&player, &secret);
+    if won {
+        let s = streak_of(&env, &contract_id, &player);
+        assert_eq!(s, 4);
+        assert_eq!(get_multiplier(s), 100_000); // 10x cap
+    }
+}
+
+/// Streak at boundary 4+: multiplier stays capped, counter still increments.
+#[test]
+fn streak_boundary_above_cap_multiplier_stays_capped() {
+    for initial in [4u32, 9, 10] {
+        let (env, client, contract_id) = setup();
+        fund(&env, &contract_id);
+        let player = Address::generate(&env);
+        inject(&env, &contract_id, &player, GamePhase::Committed, initial);
+        let secret = soroban_sdk::Bytes::from_slice(&env, &[1u8; 32]);
+        let won = client.reveal(&player, &secret);
+        if won {
+            let s = streak_of(&env, &contract_id, &player);
+            assert_eq!(s, initial + 1);
+            assert_eq!(get_multiplier(s), 100_000, "multiplier must stay at 10x for streak {s}");
+        }
+    }
+}
+
+// ── Monotonicity ──────────────────────────────────────────────────────────────
+
+/// Streak never decreases: after a win it is strictly greater than before.
+#[test]
+fn streak_never_decreases_after_win() {
+    let (env, client, contract_id) = setup();
+    fund(&env, &contract_id);
+    let player = Address::generate(&env);
+    let secret = soroban_sdk::Bytes::from_slice(&env, &[1u8; 32]);
+
+    let mut prev = 0u32;
+    for initial in [0u32, 1, 2, 3, 4] {
+        inject(&env, &contract_id, &player, GamePhase::Committed, initial);
+        let won = client.reveal(&player, &secret);
+        if won {
+            let current = streak_of(&env, &contract_id, &player);
+            assert!(
+                current > prev || current == initial + 1,
+                "streak must not decrease: was {prev}, now {current}"
+            );
+            prev = current;
+        }
+    }
+}

--- a/contract/src/ttl_tests.rs
+++ b/contract/src/ttl_tests.rs
@@ -1,0 +1,300 @@
+/// # Storage TTL Management Tests
+///
+/// ## TTL Strategy
+///
+/// All three persistent storage keys use the same threshold/extend pattern:
+///
+/// ```text
+/// extend_ttl(key, TTL_THRESHOLD = 100_000, TTL_EXTEND_TO = 500_000)
+/// ```
+///
+/// The call is made on **every read and write** so that active entries never
+/// silently expire.  The threshold avoids a redundant host call when the TTL
+/// is already healthy (> 100_000 ledgers remaining).
+///
+/// | Key              | Extended by              |
+/// |------------------|--------------------------|
+/// | `Config`         | `initialize`, `save_config`, `load_config` |
+/// | `Stats`          | `initialize`, `save_stats`, `load_stats`   |
+/// | `PlayerGame(p)`  | `save_player_game`, `load_player_game`     |
+///
+/// ## Coverage
+///
+/// | Test                                          | What is verified                        |
+/// |-----------------------------------------------|-----------------------------------------|
+/// | `initialize_extends_config_ttl`               | Config TTL ≥ TTL_EXTEND_TO after init   |
+/// | `initialize_extends_stats_ttl`                | Stats TTL ≥ TTL_EXTEND_TO after init    |
+/// | `start_game_extends_player_game_ttl`          | PlayerGame TTL ≥ TTL_EXTEND_TO          |
+/// | `start_game_extends_stats_ttl`                | Stats TTL refreshed on start_game       |
+/// | `load_config_extends_ttl`                     | get_config refreshes Config TTL         |
+/// | `load_stats_extends_ttl`                      | get_stats refreshes Stats TTL           |
+/// | `cash_out_extends_stats_ttl`                  | Stats TTL refreshed on settlement       |
+/// | `continue_streak_extends_player_game_ttl`     | PlayerGame TTL refreshed on continue    |
+/// | `admin_ops_extend_config_ttl`                 | set_fee / set_paused refresh Config TTL |
+/// | `data_persists_across_ledger_advance`         | Data readable after ledger advance      |
+/// | `ttl_refreshed_on_repeated_reads`             | TTL stays healthy across multiple reads |
+/// | `player_game_ttl_independent_per_player`      | Each player's TTL is independent        |
+use super::*;
+use soroban_sdk::testutils::{Address as _, Ledger};
+use soroban_sdk::testutils::storage::Persistent as _;
+
+// ── Constants (mirrors private contract constants) ────────────────────────────
+
+const TTL_THRESHOLD: u32 = 100_000;
+const TTL_EXTEND_TO: u32 = 500_000;
+
+// ── Harness ───────────────────────────────────────────────────────────────────
+
+fn setup() -> (Env, CoinflipContractClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(CoinflipContract, ());
+    let client = CoinflipContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.initialize(&admin, &treasury, &token, &300, &1_000_000, &100_000_000);
+    (env, client, contract_id, admin)
+}
+
+fn fund(env: &Env, contract_id: &Address) {
+    env.as_contract(contract_id, || {
+        let mut stats = CoinflipContract::load_stats(env);
+        stats.reserve_balance = 1_000_000_000;
+        CoinflipContract::save_stats(env, &stats);
+    });
+}
+
+fn commitment(env: &Env) -> BytesN<32> {
+    env.crypto()
+        .sha256(&soroban_sdk::Bytes::from_slice(env, &[7u8; 32]))
+        .into()
+}
+
+fn get_ttl(env: &Env, contract_id: &Address, key: &StorageKey) -> u32 {
+    env.as_contract(contract_id, || {
+        env.storage().persistent().get_ttl(key)
+    })
+}
+
+// ── initialize extends TTL ────────────────────────────────────────────────────
+
+/// initialize sets Config TTL to TTL_EXTEND_TO.
+#[test]
+fn initialize_extends_config_ttl() {
+    let (env, _, contract_id, _) = setup();
+    let ttl = get_ttl(&env, &contract_id, &StorageKey::Config);
+    assert_eq!(ttl, TTL_EXTEND_TO);
+}
+
+/// initialize sets Stats TTL to TTL_EXTEND_TO.
+#[test]
+fn initialize_extends_stats_ttl() {
+    let (env, _, contract_id, _) = setup();
+    let ttl = get_ttl(&env, &contract_id, &StorageKey::Stats);
+    assert_eq!(ttl, TTL_EXTEND_TO);
+}
+
+// ── start_game extends TTL ────────────────────────────────────────────────────
+
+/// start_game creates a PlayerGame entry with TTL = TTL_EXTEND_TO.
+#[test]
+fn start_game_extends_player_game_ttl() {
+    let (env, client, contract_id, _) = setup();
+    fund(&env, &contract_id);
+    let player = Address::generate(&env);
+    client.start_game(&player, &Side::Heads, &10_000_000, &commitment(&env));
+    let ttl = get_ttl(&env, &contract_id, &StorageKey::PlayerGame(player));
+    assert_eq!(ttl, TTL_EXTEND_TO);
+}
+
+/// start_game touches Stats (total_games/volume update), refreshing its TTL.
+#[test]
+fn start_game_extends_stats_ttl() {
+    let (env, client, contract_id, _) = setup();
+    fund(&env, &contract_id);
+    // Decay the Stats TTL below TTL_EXTEND_TO by advancing the ledger
+    env.ledger().with_mut(|l| l.sequence_number += TTL_THRESHOLD + 1);
+    let player = Address::generate(&env);
+    client.start_game(&player, &Side::Heads, &10_000_000, &commitment(&env));
+    let ttl = get_ttl(&env, &contract_id, &StorageKey::Stats);
+    assert_eq!(ttl, TTL_EXTEND_TO);
+}
+
+// ── read operations extend TTL ────────────────────────────────────────────────
+
+/// get_config (load_config) refreshes Config TTL to TTL_EXTEND_TO.
+#[test]
+fn load_config_extends_ttl() {
+    let (env, client, contract_id, _) = setup();
+    // Advance ledger to decay TTL below TTL_EXTEND_TO
+    env.ledger().with_mut(|l| l.sequence_number += TTL_THRESHOLD + 1);
+    client.get_config(); // triggers load_config → extend_ttl
+    let ttl = get_ttl(&env, &contract_id, &StorageKey::Config);
+    assert_eq!(ttl, TTL_EXTEND_TO);
+}
+
+/// get_stats (load_stats) refreshes Stats TTL to TTL_EXTEND_TO.
+#[test]
+fn load_stats_extends_ttl() {
+    let (env, client, contract_id, _) = setup();
+    env.ledger().with_mut(|l| l.sequence_number += TTL_THRESHOLD + 1);
+    client.get_stats(); // triggers load_stats → extend_ttl
+    let ttl = get_ttl(&env, &contract_id, &StorageKey::Stats);
+    assert_eq!(ttl, TTL_EXTEND_TO);
+}
+
+// ── settlement operations extend TTL ─────────────────────────────────────────
+
+/// cash_out updates Stats (reserve/fees), refreshing Stats TTL.
+#[test]
+fn cash_out_extends_stats_ttl() {
+    let (env, client, contract_id, _) = setup();
+    fund(&env, &contract_id);
+    let player = Address::generate(&env);
+    // Inject a Revealed game directly
+    let c: BytesN<32> = env.crypto()
+        .sha256(&soroban_sdk::Bytes::from_slice(&env, &[1u8; 32]))
+        .into();
+    let cr: BytesN<32> = env.crypto()
+        .sha256(&soroban_sdk::Bytes::from_slice(&env, &[2u8; 32]))
+        .into();
+    let game = GameState {
+        wager: 10_000_000, side: Side::Heads, streak: 1,
+        commitment: c, contract_random: cr, fee_bps: 300,
+        phase: GamePhase::Revealed, start_ledger: env.ledger().sequence(),
+    };
+    env.as_contract(&contract_id, || {
+        CoinflipContract::save_player_game(&env, &player, &game);
+    });
+    env.ledger().with_mut(|l| l.sequence_number += TTL_THRESHOLD + 1);
+    client.cash_out(&player);
+    let ttl = get_ttl(&env, &contract_id, &StorageKey::Stats);
+    assert_eq!(ttl, TTL_EXTEND_TO);
+}
+
+/// continue_streak re-saves PlayerGame, refreshing its TTL.
+#[test]
+fn continue_streak_extends_player_game_ttl() {
+    let (env, client, contract_id, _) = setup();
+    fund(&env, &contract_id);
+    let player = Address::generate(&env);
+    let c: BytesN<32> = env.crypto()
+        .sha256(&soroban_sdk::Bytes::from_slice(&env, &[1u8; 32]))
+        .into();
+    let cr: BytesN<32> = env.crypto()
+        .sha256(&soroban_sdk::Bytes::from_slice(&env, &[2u8; 32]))
+        .into();
+    let game = GameState {
+        wager: 10_000_000, side: Side::Heads, streak: 1,
+        commitment: c, contract_random: cr, fee_bps: 300,
+        phase: GamePhase::Revealed, start_ledger: env.ledger().sequence(),
+    };
+    env.as_contract(&contract_id, || {
+        CoinflipContract::save_player_game(&env, &player, &game);
+    });
+    env.ledger().with_mut(|l| l.sequence_number += TTL_THRESHOLD + 1);
+    let nc: BytesN<32> = env.crypto()
+        .sha256(&soroban_sdk::Bytes::from_slice(&env, &[42u8; 32]))
+        .into();
+    client.continue_streak(&player, &nc);
+    let ttl = get_ttl(&env, &contract_id, &StorageKey::PlayerGame(player));
+    assert_eq!(ttl, TTL_EXTEND_TO);
+}
+
+// ── admin operations extend TTL ───────────────────────────────────────────────
+
+/// set_fee (save_config) refreshes Config TTL.
+#[test]
+fn admin_set_fee_extends_config_ttl() {
+    let (env, client, contract_id, admin) = setup();
+    env.ledger().with_mut(|l| l.sequence_number += TTL_THRESHOLD + 1);
+    client.set_fee(&admin, &400);
+    let ttl = get_ttl(&env, &contract_id, &StorageKey::Config);
+    assert_eq!(ttl, TTL_EXTEND_TO);
+}
+
+/// set_paused (save_config) refreshes Config TTL.
+#[test]
+fn admin_set_paused_extends_config_ttl() {
+    let (env, client, contract_id, admin) = setup();
+    env.ledger().with_mut(|l| l.sequence_number += TTL_THRESHOLD + 1);
+    client.set_paused(&admin, &true);
+    let ttl = get_ttl(&env, &contract_id, &StorageKey::Config);
+    assert_eq!(ttl, TTL_EXTEND_TO);
+}
+
+// ── data persistence across ledger advance ────────────────────────────────────
+
+/// Config and Stats data are readable after a large ledger advance (< TTL_EXTEND_TO).
+#[test]
+fn data_persists_across_ledger_advance() {
+    let (env, client, _, _) = setup();
+    // Advance well within the TTL window
+    env.ledger().with_mut(|l| l.sequence_number += TTL_EXTEND_TO / 2);
+    // Data must still be readable and correct
+    let config = client.get_config();
+    assert_eq!(config.fee_bps, 300);
+    assert_eq!(config.min_wager, 1_000_000);
+    let stats = client.get_stats();
+    assert_eq!(stats.total_games, 0);
+}
+
+/// PlayerGame data is readable after a ledger advance within TTL window.
+#[test]
+fn player_game_persists_across_ledger_advance() {
+    let (env, client, contract_id, _) = setup();
+    fund(&env, &contract_id);
+    let player = Address::generate(&env);
+    client.start_game(&player, &Side::Tails, &10_000_000, &commitment(&env));
+    env.ledger().with_mut(|l| l.sequence_number += TTL_EXTEND_TO / 2);
+    // get_game_state triggers load_player_game → extend_ttl
+    let game = client.get_game_state(&player);
+    assert!(game.is_some());
+    assert_eq!(game.unwrap().phase, GamePhase::Committed);
+}
+
+// ── TTL refreshed on repeated reads ──────────────────────────────────────────
+
+/// Each get_config call resets Config TTL to TTL_EXTEND_TO regardless of how
+/// many times it has been called.
+#[test]
+fn ttl_refreshed_on_repeated_reads() {
+    let (env, client, contract_id, _) = setup();
+    for _ in 0..3 {
+        env.ledger().with_mut(|l| l.sequence_number += TTL_THRESHOLD + 1);
+        client.get_config();
+        assert_eq!(get_ttl(&env, &contract_id, &StorageKey::Config), TTL_EXTEND_TO);
+    }
+}
+
+// ── Per-player TTL independence ───────────────────────────────────────────────
+
+/// Each player's PlayerGame entry has its own independent TTL.
+/// Accessing one player's game does not affect another's TTL.
+#[test]
+fn player_game_ttl_independent_per_player() {
+    let (env, client, contract_id, _) = setup();
+    fund(&env, &contract_id);
+    let p1 = Address::generate(&env);
+    let p2 = Address::generate(&env);
+    client.start_game(&p1, &Side::Heads, &10_000_000, &commitment(&env));
+    client.start_game(&p2, &Side::Tails, &10_000_000, &commitment(&env));
+
+    // Advance ledger to decay both TTLs below TTL_EXTEND_TO
+    env.ledger().with_mut(|l| l.sequence_number += TTL_THRESHOLD + 1);
+
+    // Only read p1's game — should refresh p1's TTL but not p2's
+    client.get_game_state(&p1);
+
+    let ttl_p1 = get_ttl(&env, &contract_id, &StorageKey::PlayerGame(p1));
+    let ttl_p2 = get_ttl(&env, &contract_id, &StorageKey::PlayerGame(p2.clone()));
+
+    assert_eq!(ttl_p1, TTL_EXTEND_TO, "p1 TTL must be refreshed after read");
+    // p2's TTL was not refreshed — it decayed by TTL_THRESHOLD + 1
+    assert_eq!(
+        ttl_p2,
+        TTL_EXTEND_TO - (TTL_THRESHOLD + 1),
+        "p2 TTL must not be affected by p1 read"
+    );
+}

--- a/contract/src/wager_limit_tests.rs
+++ b/contract/src/wager_limit_tests.rs
@@ -1,0 +1,235 @@
+/// # Wager Limit Enforcement Tests
+///
+/// ## Strategy
+///
+/// Wager limits are enforced in `start_game` using **inclusive** bounds:
+///
+/// ```text
+/// Accepted: wager >= config.min_wager && wager <= config.max_wager
+/// Rejected: wager < config.min_wager  → Error::WagerBelowMinimum  (code 1)
+/// Rejected: wager > config.max_wager  → Error::WagerAboveMaximum  (code 2)
+/// ```
+///
+/// The guards use strict inequalities (`<` / `>`), so exactly `min_wager` and
+/// `max_wager` are **accepted**.  This is the "inclusive boundary" contract.
+///
+/// ## Coverage
+///
+/// | Test                                    | Boundary point        |
+/// |-----------------------------------------|-----------------------|
+/// | `min_minus_one_rejected`                | min − 1               |
+/// | `min_accepted`                          | min (inclusive)       |
+/// | `min_plus_one_accepted`                 | min + 1               |
+/// | `max_minus_one_accepted`                | max − 1               |
+/// | `max_accepted`                          | max (inclusive)       |
+/// | `max_plus_one_rejected`                 | max + 1               |
+/// | `zero_rejected`                         | 0 (below any min > 0) |
+/// | `negative_rejected`                     | −1                    |
+/// | `i128_min_rejected`                     | i128::MIN             |
+/// | `i128_max_rejected`                     | i128::MAX             |
+/// | `limit_update_takes_effect`             | post-update boundary  |
+/// | `limit_update_old_min_now_rejected`     | old min after update  |
+/// | `limit_update_old_max_now_rejected`     | old max after update  |
+/// | `limit_update_unauthorized`             | admin guard           |
+/// | `limit_update_invalid_min_gte_max`      | min >= max guard      |
+use super::*;
+use soroban_sdk::testutils::Address as _;
+
+// ── Harness ───────────────────────────────────────────────────────────────────
+
+const MIN: i128 = 1_000_000;   // 1 XLM in stroops
+const MAX: i128 = 100_000_000; // 100 XLM in stroops
+
+fn setup() -> (Env, CoinflipContractClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(CoinflipContract, ());
+    let client = CoinflipContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.initialize(&admin, &treasury, &token, &300, &MIN, &MAX);
+    (env, client, contract_id, admin)
+}
+
+fn fund(env: &Env, contract_id: &Address, amount: i128) {
+    env.as_contract(contract_id, || {
+        let mut stats = CoinflipContract::load_stats(env);
+        stats.reserve_balance = amount;
+        CoinflipContract::save_stats(env, &stats);
+    });
+}
+
+fn commitment(env: &Env) -> BytesN<32> {
+    env.crypto()
+        .sha256(&soroban_sdk::Bytes::from_slice(env, &[7u8; 32]))
+        .into()
+}
+
+// ── Boundary tests ────────────────────────────────────────────────────────────
+
+#[test]
+fn min_minus_one_rejected() {
+    let (env, client, contract_id, _) = setup();
+    fund(&env, &contract_id, i128::MAX / 2);
+    let player = Address::generate(&env);
+    let result = client.try_start_game(&player, &Side::Heads, &(MIN - 1), &commitment(&env));
+    assert_eq!(result, Err(Ok(Error::WagerBelowMinimum)));
+}
+
+#[test]
+fn min_accepted() {
+    let (env, client, contract_id, _) = setup();
+    fund(&env, &contract_id, i128::MAX / 2);
+    let player = Address::generate(&env);
+    // Exactly at min must succeed (inclusive lower bound).
+    assert!(client.try_start_game(&player, &Side::Heads, &MIN, &commitment(&env)).is_ok());
+}
+
+#[test]
+fn min_plus_one_accepted() {
+    let (env, client, contract_id, _) = setup();
+    fund(&env, &contract_id, i128::MAX / 2);
+    let player = Address::generate(&env);
+    assert!(client.try_start_game(&player, &Side::Heads, &(MIN + 1), &commitment(&env)).is_ok());
+}
+
+#[test]
+fn max_minus_one_accepted() {
+    let (env, client, contract_id, _) = setup();
+    fund(&env, &contract_id, i128::MAX / 2);
+    let player = Address::generate(&env);
+    assert!(client.try_start_game(&player, &Side::Heads, &(MAX - 1), &commitment(&env)).is_ok());
+}
+
+#[test]
+fn max_accepted() {
+    let (env, client, contract_id, _) = setup();
+    fund(&env, &contract_id, i128::MAX / 2);
+    let player = Address::generate(&env);
+    // Exactly at max must succeed (inclusive upper bound).
+    assert!(client.try_start_game(&player, &Side::Heads, &MAX, &commitment(&env)).is_ok());
+}
+
+#[test]
+fn max_plus_one_rejected() {
+    let (env, client, contract_id, _) = setup();
+    fund(&env, &contract_id, i128::MAX / 2);
+    let player = Address::generate(&env);
+    let result = client.try_start_game(&player, &Side::Heads, &(MAX + 1), &commitment(&env));
+    assert_eq!(result, Err(Ok(Error::WagerAboveMaximum)));
+}
+
+#[test]
+fn zero_rejected() {
+    let (env, client, contract_id, _) = setup();
+    fund(&env, &contract_id, i128::MAX / 2);
+    let player = Address::generate(&env);
+    let result = client.try_start_game(&player, &Side::Heads, &0, &commitment(&env));
+    assert_eq!(result, Err(Ok(Error::WagerBelowMinimum)));
+}
+
+#[test]
+fn negative_rejected() {
+    let (env, client, contract_id, _) = setup();
+    fund(&env, &contract_id, i128::MAX / 2);
+    let player = Address::generate(&env);
+    let result = client.try_start_game(&player, &Side::Heads, &(-1), &commitment(&env));
+    assert_eq!(result, Err(Ok(Error::WagerBelowMinimum)));
+}
+
+#[test]
+fn i128_min_rejected() {
+    let (env, client, contract_id, _) = setup();
+    fund(&env, &contract_id, i128::MAX / 2);
+    let player = Address::generate(&env);
+    let result = client.try_start_game(&player, &Side::Heads, &i128::MIN, &commitment(&env));
+    assert_eq!(result, Err(Ok(Error::WagerBelowMinimum)));
+}
+
+#[test]
+fn i128_max_rejected() {
+    let (env, client, contract_id, _) = setup();
+    fund(&env, &contract_id, i128::MAX / 2);
+    let player = Address::generate(&env);
+    // i128::MAX far exceeds max_wager; must be rejected as above maximum.
+    let result = client.try_start_game(&player, &Side::Heads, &i128::MAX, &commitment(&env));
+    assert_eq!(result, Err(Ok(Error::WagerAboveMaximum)));
+}
+
+// ── Limit update tests ────────────────────────────────────────────────────────
+
+#[test]
+fn limit_update_takes_effect_immediately() {
+    let (env, client, contract_id, admin) = setup();
+    fund(&env, &contract_id, i128::MAX / 2);
+
+    // Tighten limits: new range [5_000_000, 10_000_000]
+    let new_min: i128 = 5_000_000;
+    let new_max: i128 = 10_000_000;
+    client.set_wager_limits(&admin, &new_min, &new_max);
+
+    let player = Address::generate(&env);
+
+    // Exactly new_min accepted
+    assert!(client
+        .try_start_game(&player, &Side::Heads, &new_min, &commitment(&env))
+        .is_ok());
+
+    // Exactly new_max accepted (need a fresh player — no active game)
+    let player2 = Address::generate(&env);
+    assert!(client
+        .try_start_game(&player2, &Side::Heads, &new_max, &commitment(&env))
+        .is_ok());
+}
+
+#[test]
+fn limit_update_old_min_now_rejected() {
+    let (env, client, contract_id, admin) = setup();
+    fund(&env, &contract_id, i128::MAX / 2);
+
+    // Raise the minimum above the old MIN
+    let new_min: i128 = MIN + 1_000_000;
+    client.set_wager_limits(&admin, &new_min, &MAX);
+
+    let player = Address::generate(&env);
+    // Old MIN is now below the new minimum → rejected
+    let result = client.try_start_game(&player, &Side::Heads, &MIN, &commitment(&env));
+    assert_eq!(result, Err(Ok(Error::WagerBelowMinimum)));
+}
+
+#[test]
+fn limit_update_old_max_now_rejected() {
+    let (env, client, contract_id, admin) = setup();
+    fund(&env, &contract_id, i128::MAX / 2);
+
+    // Lower the maximum below the old MAX
+    let new_max: i128 = MAX - 1_000_000;
+    client.set_wager_limits(&admin, &MIN, &new_max);
+
+    let player = Address::generate(&env);
+    // Old MAX is now above the new maximum → rejected
+    let result = client.try_start_game(&player, &Side::Heads, &MAX, &commitment(&env));
+    assert_eq!(result, Err(Ok(Error::WagerAboveMaximum)));
+}
+
+#[test]
+fn limit_update_unauthorized() {
+    let (env, client, _, _) = setup();
+    let non_admin = Address::generate(&env);
+    let result = client.try_set_wager_limits(&non_admin, &MIN, &MAX);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn limit_update_invalid_min_gte_max() {
+    let (env, client, _, admin) = setup();
+
+    // min == max
+    let result = client.try_set_wager_limits(&admin, &MIN, &MIN);
+    assert_eq!(result, Err(Ok(Error::InvalidWagerLimits)));
+
+    // min > max
+    let result = client.try_set_wager_limits(&admin, &MAX, &MIN);
+    assert_eq!(result, Err(Ok(Error::InvalidWagerLimits)));
+}


### PR DESCRIPTION
- Add wager_limit_tests: boundary conditions at min-1/min/min+1, max-1/max/max+1, zero, negative, i128::MIN/MAX, limit update enforcement and admin guard tests
- Add phase_transition_tests: all valid transitions (Committed→Revealed→Completed), all invalid phase rejections, phase consistency invariants, and multi-player isolation tests
- Add streak_tests: streak init at zero, increment by exactly one per win, preservation across continue_streak, loss deletion, 10-win sequence, boundary and monotonicity tests
- Add ttl_tests: TTL extension on initialize/read/write/admin ops for Config, Stats, and PlayerGame keys; data persistence across ledger advance; per-player TTL independence

Closes #416
Closes #417
Closes #418 
Closes #419 