### PR TITLE
test: add comprehensive responsive design tests

### DIFF
--- a/frontend/tests/e2e/RESPONSIVE_PATTERNS.md
+++ b/frontend/tests/e2e/RESPONSIVE_PATTERNS.md
@@ -1,0 +1,42 @@
+# Responsive Patterns
+
+`frontend/tests/e2e/responsive.spec.ts` validates the responsive behavior that the current Tossd landing page actually ships today.
+
+## Viewport matrix
+
+- Mobile: `375x812`
+- Tablet: `768x1024`
+- Desktop: `1440x900`
+
+## Orientation coverage
+
+- Mobile portrait: `375x812`
+- Mobile landscape: `812x375`
+- Tablet portrait: `768x1024`
+- Tablet landscape: `1024x768`
+- Desktop portrait: `900x1440`
+- Desktop landscape: `1440x900`
+
+Orientation tests intentionally validate width-driven breakpoint changes after resize. In the current implementation, rotating a mobile or tablet viewport into landscape can move the header from the hamburger menu to the desktop navigation because the header breakpoint is based on width, not device category.
+
+## Breakpoints exercised by the suite
+
+- `768px`: `NavBar` swaps between desktop navigation and the mobile menu trigger.
+- `900px`: the `#play` section switches between a two-column grid and a stacked layout.
+- `480px` and `640px`: smaller component-level breakpoints exist in the component CSS and are indirectly covered by the mobile viewport assertions and overflow checks.
+
+## Interaction strategy
+
+- Desktop assertions validate standard mouse-driven actions such as opening and closing the wallet modal.
+- Mobile assertions validate tap-sized controls and tap interactions for the menu and wallet flow.
+- Touch target checks enforce the existing `44px` minimum interactive sizing used throughout the component styles.
+
+## Responsive media strategy
+
+The current frontend does not ship breakpoint-specific raster assets. The responsive suite therefore asserts that the landing page stays fully responsive without `<img>`, `<picture>`, `srcset`, or viewport-specific image requests.
+
+If responsive imagery is introduced later, extend the suite to assert:
+
+- `srcset` or `<picture>` source selection at `375`, `768`, and `1440` widths
+- stable aspect ratios across portrait and landscape
+- no oversized image downloads on mobile

--- a/frontend/tests/e2e/responsive.spec.ts
+++ b/frontend/tests/e2e/responsive.spec.ts
@@ -1,27 +1,252 @@
-import { test, expect } from '@playwright/test';
-import { devices } from '@playwright/test';
+import { test, expect, type Locator, type Page } from "@playwright/test";
 
-test.describe('Responsive Behavior @mobile', () => {
-  test('landing page responsive desktop/mobile', async ({ page }) => {
-    // Desktop
-    await page.setViewportSize({ width: 1920, height: 1080 });
-    await page.goto('/');
-    await expect(page).toHaveScreenshot('landing-desktop.png');
-    
-    // Mobile
-    await page.setViewportSize({ width: 375, height: 812 });
-    await page.goto('/');
-    await expect(page).toHaveScreenshot('landing-mobile.png');
+const VIEWPORTS = {
+  mobile: { width: 375, height: 812 },
+  tablet: { width: 768, height: 1024 },
+  desktop: { width: 1440, height: 900 },
+} as const;
+
+const ORIENTATIONS = {
+  mobile: {
+    portrait: { width: 375, height: 812 },
+    landscape: { width: 812, height: 375 },
+  },
+  tablet: {
+    portrait: { width: 768, height: 1024 },
+    landscape: { width: 1024, height: 768 },
+  },
+  desktop: {
+    portrait: { width: 900, height: 1440 },
+    landscape: { width: 1440, height: 900 },
+  },
+} as const;
+
+type LayoutMode = "stacked" | "split";
+type NavMode = "mobile" | "desktop";
+
+function primaryNav(page: Page) {
+  return page.getByRole("navigation", { name: /primary navigation/i });
+}
+
+function mobileMenuTrigger(page: Page) {
+  return page.getByRole("button", { name: /open navigation menu/i });
+}
+
+async function loadHome(page: Page, viewport: { width: number; height: number }) {
+  await page.setViewportSize(viewport);
+  await page.goto("/");
+  await page.waitForLoadState("networkidle");
+}
+
+async function resize(page: Page, viewport: { width: number; height: number }) {
+  await page.setViewportSize(viewport);
+  await page.waitForTimeout(100);
+}
+
+async function expectNoHorizontalOverflow(page: Page) {
+  const overflow = await page.evaluate(() => {
+    const root = document.documentElement;
+    return root.scrollWidth - root.clientWidth;
   });
-  
-  test('game interface responsive', async ({ page }) => {
-    test.use(devices['iPhone 12']);
-    
-    await page.goto('/');
-    // Interact to load game
-    await page.getByRole('button', { name: /play|start/i }).first().click();
-    await expect(page.locator('.game-container')).toBeVisible();
-    await expect(page).toHaveScreenshot('game-mobile.png');
+
+  expect(overflow).toBeLessThanOrEqual(1);
+}
+
+async function expectNavMode(page: Page, mode: NavMode) {
+  if (mode === "mobile") {
+    await expect(mobileMenuTrigger(page)).toBeVisible();
+    await expect(primaryNav(page)).toBeHidden();
+    return;
+  }
+
+  await expect(primaryNav(page)).toBeVisible();
+  await expect(mobileMenuTrigger(page)).toBeHidden();
+}
+
+async function expectPlayGridLayout(page: Page, mode: LayoutMode) {
+  await page.locator("#play").scrollIntoViewIfNeeded();
+
+  const playPanel = page.locator(".playPanel");
+  const statusPanel = page.locator(".statusPanel");
+
+  await expect(playPanel).toBeVisible();
+  await expect(statusPanel).toBeVisible();
+
+  const playBox = await playPanel.boundingBox();
+  const statusBox = await statusPanel.boundingBox();
+
+  expect(playBox).not.toBeNull();
+  expect(statusBox).not.toBeNull();
+
+  if (!playBox || !statusBox) {
+    return;
+  }
+
+  if (mode === "stacked") {
+    expect(Math.abs(playBox.x - statusBox.x)).toBeLessThanOrEqual(4);
+    expect(statusBox.y).toBeGreaterThan(playBox.y + playBox.height - 1);
+    return;
+  }
+
+  expect(statusBox.x).toBeGreaterThan(playBox.x + playBox.width - 1);
+  expect(Math.abs(playBox.y - statusBox.y)).toBeLessThanOrEqual(8);
+}
+
+async function expectMinimumTouchTarget(locator: Locator, label: string) {
+  const box = await locator.boundingBox();
+
+  expect(box, `${label} should have a measurable bounding box`).not.toBeNull();
+
+  if (!box) {
+    return;
+  }
+
+  expect(box.width, `${label} should be at least 44px wide`).toBeGreaterThanOrEqual(44);
+  expect(box.height, `${label} should be at least 44px tall`).toBeGreaterThanOrEqual(44);
+}
+
+test.describe("Responsive layout matrix @e2e", () => {
+  const expectations = {
+    mobile: { nav: "mobile" as const, layout: "stacked" as const },
+    tablet: { nav: "mobile" as const, layout: "stacked" as const },
+    desktop: { nav: "desktop" as const, layout: "split" as const },
+  };
+
+  for (const [device, viewport] of Object.entries(VIEWPORTS) as Array<
+    [keyof typeof VIEWPORTS, (typeof VIEWPORTS)[keyof typeof VIEWPORTS]]
+  >) {
+    test(`${device}: landing page stays usable across the target viewport @e2e`, async ({ page }) => {
+      await loadHome(page, viewport);
+
+      await expect(page.getByRole("banner")).toBeVisible();
+      await expect(page.locator("[aria-label='Hero']")).toBeVisible();
+      await expect(page.locator("#play")).toBeVisible();
+      await expect(page.locator("footer[aria-label='Site footer']")).toBeVisible();
+
+      await expectNavMode(page, expectations[device].nav);
+      await expectPlayGridLayout(page, expectations[device].layout);
+      await expectNoHorizontalOverflow(page);
+    });
+  }
+});
+
+test.describe("Breakpoint transitions @e2e", () => {
+  test("768px and 769px swap navigation modes cleanly @e2e", async ({ page }) => {
+    await loadHome(page, { width: 768, height: 1024 });
+    await expectNavMode(page, "mobile");
+
+    await resize(page, { width: 769, height: 1024 });
+    await expectNavMode(page, "desktop");
+    await expectNoHorizontalOverflow(page);
+  });
+
+  test("900px and 901px swap the play grid layout cleanly @e2e", async ({ page }) => {
+    await loadHome(page, { width: 900, height: 900 });
+    await expectPlayGridLayout(page, "stacked");
+
+    await resize(page, { width: 901, height: 900 });
+    await expectPlayGridLayout(page, "split");
+    await expectNoHorizontalOverflow(page);
   });
 });
 
+test.describe("Orientation changes @e2e", () => {
+  const orientationExpectations = {
+    mobile: {
+      portrait: { nav: "mobile" as const, layout: "stacked" as const },
+      landscape: { nav: "desktop" as const, layout: "stacked" as const },
+    },
+    tablet: {
+      portrait: { nav: "mobile" as const, layout: "stacked" as const },
+      landscape: { nav: "desktop" as const, layout: "split" as const },
+    },
+    desktop: {
+      portrait: { nav: "desktop" as const, layout: "stacked" as const },
+      landscape: { nav: "desktop" as const, layout: "split" as const },
+    },
+  };
+
+  for (const [device, viewports] of Object.entries(ORIENTATIONS) as Array<
+    [keyof typeof ORIENTATIONS, (typeof ORIENTATIONS)[keyof typeof ORIENTATIONS]]
+  >) {
+    test(`${device}: portrait and landscape stay responsive after rotation @e2e`, async ({ page }) => {
+      await loadHome(page, viewports.portrait);
+
+      await expectNavMode(page, orientationExpectations[device].portrait.nav);
+      await expectPlayGridLayout(page, orientationExpectations[device].portrait.layout);
+
+      await resize(page, viewports.landscape);
+
+      await expect(page.getByRole("banner")).toBeVisible();
+      await expect(page.locator("[aria-label='Hero']")).toBeVisible();
+      await expect(page.locator("#play")).toBeVisible();
+      await expectNavMode(page, orientationExpectations[device].landscape.nav);
+      await expectPlayGridLayout(page, orientationExpectations[device].landscape.layout);
+      await expectNoHorizontalOverflow(page);
+    });
+  }
+});
+
+test.describe("Pointer interactions @e2e", () => {
+  test("desktop mouse interactions keep primary actions available @e2e", async ({ page }) => {
+    await loadHome(page, VIEWPORTS.desktop);
+
+    const connectWallet = page.getByRole("button", { name: /connect wallet/i }).first();
+
+    await expect(connectWallet).toBeVisible();
+    await connectWallet.click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await page.getByRole("button", { name: /close wallet modal/i }).click();
+    await expect(page.getByRole("dialog")).not.toBeVisible();
+  });
+
+});
+
+test.describe("Touch interactions @e2e", () => {
+  test.use({ hasTouch: true, viewport: VIEWPORTS.mobile });
+
+  test("mobile controls stay touch-friendly and tappable @e2e", async ({ page }) => {
+    await loadHome(page, VIEWPORTS.mobile);
+
+    const menuButton = mobileMenuTrigger(page);
+    await expectMinimumTouchTarget(menuButton, "Mobile navigation trigger");
+
+    await menuButton.tap();
+    const mobileWalletButton = page.getByRole("button", { name: /connect wallet/i });
+
+    await expect(page.getByRole("dialog", { name: /navigation menu/i })).toBeVisible();
+    await expectMinimumTouchTarget(mobileWalletButton, "Mobile wallet button");
+
+    await mobileWalletButton.tap();
+    await expect(page.getByRole("dialog", { name: /connect wallet/i })).toBeVisible();
+
+    const freighterButton = page.getByRole("button", { name: /freighter/i });
+    await expectMinimumTouchTarget(freighterButton, "Freighter wallet option");
+    await freighterButton.tap();
+
+    await expect(page.getByText(/connected/i)).toBeVisible({ timeout: 3_000 });
+  });
+});
+
+test.describe("Responsive media strategy @e2e", () => {
+  test("landing page currently uses layout responsiveness without raster image variants @e2e", async ({ page }) => {
+    for (const viewport of Object.values(VIEWPORTS)) {
+      await loadHome(page, viewport);
+
+      await expect(page.locator("img, picture, source[srcset], img[srcset], img[sizes]")).toHaveCount(0);
+
+      const imageRequests = await page.evaluate(() =>
+        performance
+          .getEntriesByType("resource")
+          .filter(
+            (entry) =>
+              (entry as PerformanceResourceTiming).initiatorType === "img" ||
+              /\.(png|jpe?g|gif|webp|avif|svg)(\?|$)/i.test(entry.name)
+          ).length
+      );
+
+      expect(imageRequests).toBe(0);
+      await expectNoHorizontalOverflow(page);
+    }
+  });
+});


### PR DESCRIPTION
Closes #427

---

# Responsive Patterns

`frontend/tests/e2e/responsive.spec.ts` validates the responsive behavior that the current Tossd landing page actually ships today.

## Viewport matrix

- Mobile: `375x812`
- Tablet: `768x1024`
- Desktop: `1440x900`

## Orientation coverage

- Mobile portrait: `375x812`
- Mobile landscape: `812x375`
- Tablet portrait: `768x1024`
- Tablet landscape: `1024x768`
- Desktop portrait: `900x1440`
- Desktop landscape: `1440x900`

Orientation tests intentionally validate width-driven breakpoint changes after resize. In the current implementation, rotating a mobile or tablet viewport into landscape can move the header from the hamburger menu to the desktop navigation because the header breakpoint is based on width, not device category.

## Breakpoints exercised by the suite

- `768px`: `NavBar` swaps between desktop navigation and the mobile menu trigger.
- `900px`: the `#play` section switches between a two-column grid and a stacked layout.
- `480px` and `640px`: smaller component-level breakpoints exist in the component CSS and are indirectly covered by the mobile viewport assertions and overflow checks.

## Interaction strategy

- Desktop assertions validate standard mouse-driven actions such as opening and closing the wallet modal.
- Mobile assertions validate tap-sized controls and tap interactions for the menu and wallet flow.
- Touch target checks enforce the existing `44px` minimum interactive sizing used throughout the component styles.

## Responsive media strategy

The current frontend does not ship breakpoint-specific raster assets. The responsive suite therefore asserts that the landing page stays fully responsive without `<img>`, `<picture>`, `srcset`, or viewport-specific image requests.

If responsive imagery is introduced later, extend the suite to assert:

- `srcset` or `<picture>` source selection at `375`, `768`, and `1440` widths
- stable aspect ratios across portrait and landscape
- no oversized image downloads on mobile
