### PR TITLE
Feat/rbac admin operations v2

### DIFF
--- a/contract/src/governance_tests.rs
+++ b/contract/src/governance_tests.rs
@@ -1,0 +1,455 @@
+//! # Governance Tests
+//!
+//! Tests for the proposal/voting/execution lifecycle.
+
+use super::*;
+use soroban_sdk::testutils::{Address as _, Ledger};
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+fn setup(env: &Env) -> (Address, Address, CoinflipContractClient) {
+    env.mock_all_auths();
+    let contract_id = env.register(CoinflipContract, ());
+    let client = CoinflipContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    let treasury = Address::generate(env);
+    let token = Address::generate(env);
+    client.initialize(&admin, &treasury, &token, &300, &1_000_000, &100_000_000);
+    (admin, contract_id, client)
+}
+
+fn add_voters(client: &CoinflipContractClient, admin: &Address, voters: &[Address]) {
+    for v in voters {
+        client.add_voter(admin, v);
+    }
+}
+
+fn advance_past_deadline(env: &Env) {
+    env.ledger().with_mut(|l| l.sequence_number += VOTING_PERIOD_LEDGERS + 1);
+}
+
+// ── add_voter / remove_voter ──────────────────────────────────────────────────
+
+#[test]
+fn test_add_voter_succeeds_for_admin() {
+    let env = Env::default();
+    let (admin, _, client) = setup(&env);
+    let voter = Address::generate(&env);
+    assert!(client.try_add_voter(&admin, &voter).is_ok());
+    let voters = client.get_voters();
+    assert_eq!(voters.len(), 1);
+    assert_eq!(voters.get(0).unwrap(), voter);
+}
+
+#[test]
+fn test_add_voter_rejects_non_admin() {
+    let env = Env::default();
+    let (_, _, client) = setup(&env);
+    let stranger = Address::generate(&env);
+    let voter = Address::generate(&env);
+    assert_eq!(client.try_add_voter(&stranger, &voter), Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn test_add_voter_deduplicates() {
+    let env = Env::default();
+    let (admin, _, client) = setup(&env);
+    let voter = Address::generate(&env);
+    client.add_voter(&admin, &voter);
+    client.add_voter(&admin, &voter); // second call is a no-op
+    assert_eq!(client.get_voters().len(), 1);
+}
+
+#[test]
+fn test_remove_voter_succeeds() {
+    let env = Env::default();
+    let (admin, _, client) = setup(&env);
+    let voter = Address::generate(&env);
+    client.add_voter(&admin, &voter);
+    client.remove_voter(&admin, &voter);
+    assert_eq!(client.get_voters().len(), 0);
+}
+
+#[test]
+fn test_remove_voter_rejects_non_admin() {
+    let env = Env::default();
+    let (admin, _, client) = setup(&env);
+    let voter = Address::generate(&env);
+    client.add_voter(&admin, &voter);
+    let stranger = Address::generate(&env);
+    assert_eq!(client.try_remove_voter(&stranger, &voter), Err(Ok(Error::Unauthorized)));
+}
+
+// ── propose ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_propose_succeeds_for_admin() {
+    let env = Env::default();
+    let (admin, _, client) = setup(&env);
+    let id = client.propose(&admin, &ProposalAction::SetFee(400));
+    assert_eq!(id, 0);
+    let p = client.get_proposal(&0).unwrap();
+    assert_eq!(p.id, 0);
+    assert_eq!(p.status, ProposalStatus::Active);
+    assert_eq!(p.votes_for, 0);
+}
+
+#[test]
+fn test_propose_succeeds_for_registered_voter() {
+    let env = Env::default();
+    let (admin, _, client) = setup(&env);
+    let voter = Address::generate(&env);
+    client.add_voter(&admin, &voter);
+    let id = client.propose(&voter, &ProposalAction::SetFee(400));
+    assert_eq!(id, 0);
+}
+
+#[test]
+fn test_propose_rejects_unregistered_caller() {
+    let env = Env::default();
+    let (_, _, client) = setup(&env);
+    let stranger = Address::generate(&env);
+    assert_eq!(
+        client.try_propose(&stranger, &ProposalAction::SetFee(400)),
+        Err(Ok(Error::Unauthorized))
+    );
+}
+
+#[test]
+fn test_propose_increments_id() {
+    let env = Env::default();
+    let (admin, _, client) = setup(&env);
+    let id0 = client.propose(&admin, &ProposalAction::SetFee(400));
+    let id1 = client.propose(&admin, &ProposalAction::SetPaused(true));
+    assert_eq!(id0, 0);
+    assert_eq!(id1, 1);
+}
+
+#[test]
+fn test_proposal_deadline_is_set() {
+    let env = Env::default();
+    let (admin, _, client) = setup(&env);
+    let current = env.ledger().sequence();
+    client.propose(&admin, &ProposalAction::SetFee(400));
+    let p = client.get_proposal(&0).unwrap();
+    assert_eq!(p.deadline_ledger, current + VOTING_PERIOD_LEDGERS);
+}
+
+// ── vote ──────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_vote_approve_increments_votes_for() {
+    let env = Env::default();
+    let (admin, _, client) = setup(&env);
+    let voter = Address::generate(&env);
+    client.add_voter(&admin, &voter);
+    client.propose(&admin, &ProposalAction::SetFee(400));
+    client.vote(&voter, &0, &true);
+    let p = client.get_proposal(&0).unwrap();
+    assert_eq!(p.votes_for, 1);
+    assert_eq!(p.votes_against, 0);
+}
+
+#[test]
+fn test_vote_reject_increments_votes_against() {
+    let env = Env::default();
+    let (admin, _, client) = setup(&env);
+    let voter = Address::generate(&env);
+    client.add_voter(&admin, &voter);
+    client.propose(&admin, &ProposalAction::SetFee(400));
+    client.vote(&voter, &0, &false);
+    let p = client.get_proposal(&0).unwrap();
+    assert_eq!(p.votes_for, 0);
+    assert_eq!(p.votes_against, 1);
+}
+
+#[test]
+fn test_vote_rejects_non_voter() {
+    let env = Env::default();
+    let (admin, _, client) = setup(&env);
+    client.propose(&admin, &ProposalAction::SetFee(400));
+    let stranger = Address::generate(&env);
+    assert_eq!(
+        client.try_vote(&stranger, &0, &true),
+        Err(Ok(Error::Unauthorized))
+    );
+}
+
+#[test]
+fn test_vote_rejects_double_vote() {
+    let env = Env::default();
+    let (admin, _, client) = setup(&env);
+    let voter = Address::generate(&env);
+    client.add_voter(&admin, &voter);
+    client.propose(&admin, &ProposalAction::SetFee(400));
+    client.vote(&voter, &0, &true);
+    assert_eq!(
+        client.try_vote(&voter, &0, &true),
+        Err(Ok(Error::AlreadyVoted))
+    );
+}
+
+#[test]
+fn test_vote_rejects_after_deadline() {
+    let env = Env::default();
+    let (admin, _, client) = setup(&env);
+    let voter = Address::generate(&env);
+    client.add_voter(&admin, &voter);
+    client.propose(&admin, &ProposalAction::SetFee(400));
+    advance_past_deadline(&env);
+    assert_eq!(
+        client.try_vote(&voter, &0, &true),
+        Err(Ok(Error::VotingClosed))
+    );
+}
+
+#[test]
+fn test_vote_rejects_on_nonexistent_proposal() {
+    let env = Env::default();
+    let (admin, _, client) = setup(&env);
+    let voter = Address::generate(&env);
+    client.add_voter(&admin, &voter);
+    assert_eq!(
+        client.try_vote(&voter, &99, &true),
+        Err(Ok(Error::ProposalNotFound))
+    );
+}
+
+// ── execute_proposal ──────────────────────────────────────────────────────────
+
+#[test]
+fn test_execute_set_fee_applies_change() {
+    let env = Env::default();
+    let (admin, contract_id, client) = setup(&env);
+    let voters: Vec<Address> = (0..3).map(|_| Address::generate(&env)).collect();
+    add_voters(&client, &admin, &voters);
+
+    client.propose(&admin, &ProposalAction::SetFee(400));
+    // 2 of 3 vote yes → 66% > 51%
+    client.vote(&voters[0], &0, &true);
+    client.vote(&voters[1], &0, &true);
+
+    advance_past_deadline(&env);
+    client.execute_proposal(&admin, &0);
+
+    let cfg = client.get_config();
+    assert_eq!(cfg.fee_bps, 400);
+
+    let p = client.get_proposal(&0).unwrap();
+    assert_eq!(p.status, ProposalStatus::Executed);
+}
+
+#[test]
+fn test_execute_set_wager_limits_applies_change() {
+    let env = Env::default();
+    let (admin, _, client) = setup(&env);
+    let voters: Vec<Address> = (0..2).map(|_| Address::generate(&env)).collect();
+    add_voters(&client, &admin, &voters);
+
+    client.propose(&admin, &ProposalAction::SetWagerLimits(2_000_000, 200_000_000));
+    client.vote(&voters[0], &0, &true);
+    client.vote(&voters[1], &0, &true);
+
+    advance_past_deadline(&env);
+    client.execute_proposal(&admin, &0);
+
+    let cfg = client.get_config();
+    assert_eq!(cfg.min_wager, 2_000_000);
+    assert_eq!(cfg.max_wager, 200_000_000);
+}
+
+#[test]
+fn test_execute_set_paused_applies_change() {
+    let env = Env::default();
+    let (admin, _, client) = setup(&env);
+    let voter = Address::generate(&env);
+    client.add_voter(&admin, &voter);
+
+    client.propose(&admin, &ProposalAction::SetPaused(true));
+    client.vote(&voter, &0, &true);
+
+    advance_past_deadline(&env);
+    client.execute_proposal(&admin, &0);
+
+    assert!(client.get_config().paused);
+}
+
+#[test]
+fn test_execute_set_treasury_applies_change() {
+    let env = Env::default();
+    let (admin, _, client) = setup(&env);
+    let voter = Address::generate(&env);
+    client.add_voter(&admin, &voter);
+    let new_treasury = Address::generate(&env);
+
+    client.propose(&admin, &ProposalAction::SetTreasury(new_treasury.clone()));
+    client.vote(&voter, &0, &true);
+
+    advance_past_deadline(&env);
+    client.execute_proposal(&admin, &0);
+
+    assert_eq!(client.get_config().treasury, new_treasury);
+}
+
+#[test]
+fn test_execute_set_multipliers_applies_change() {
+    let env = Env::default();
+    let (admin, _, client) = setup(&env);
+    let voter = Address::generate(&env);
+    client.add_voter(&admin, &voter);
+
+    let new_m = MultiplierConfig { streak1: 20_000, streak2: 40_000, streak3: 70_000, streak4_plus: 110_000 };
+    client.propose(&admin, &ProposalAction::SetMultipliers(new_m.clone()));
+    client.vote(&voter, &0, &true);
+
+    advance_past_deadline(&env);
+    client.execute_proposal(&admin, &0);
+
+    assert_eq!(client.get_config().multipliers, new_m);
+}
+
+#[test]
+fn test_execute_rejects_while_voting_open() {
+    let env = Env::default();
+    let (admin, _, client) = setup(&env);
+    let voter = Address::generate(&env);
+    client.add_voter(&admin, &voter);
+    client.propose(&admin, &ProposalAction::SetFee(400));
+    client.vote(&voter, &0, &true);
+    // Do NOT advance past deadline
+    assert_eq!(
+        client.try_execute_proposal(&admin, &0),
+        Err(Ok(Error::VotingOpen))
+    );
+}
+
+#[test]
+fn test_execute_rejects_threshold_not_met() {
+    let env = Env::default();
+    let (admin, _, client) = setup(&env);
+    let voters: Vec<Address> = (0..3).map(|_| Address::generate(&env)).collect();
+    add_voters(&client, &admin, &voters);
+
+    client.propose(&admin, &ProposalAction::SetFee(400));
+    // Only 1 of 3 votes yes → 33% < 51%
+    client.vote(&voters[0], &0, &true);
+
+    advance_past_deadline(&env);
+    assert_eq!(
+        client.try_execute_proposal(&admin, &0),
+        Err(Ok(Error::ThresholdNotMet))
+    );
+}
+
+#[test]
+fn test_execute_rejects_already_executed() {
+    let env = Env::default();
+    let (admin, _, client) = setup(&env);
+    let voter = Address::generate(&env);
+    client.add_voter(&admin, &voter);
+    client.propose(&admin, &ProposalAction::SetFee(400));
+    client.vote(&voter, &0, &true);
+    advance_past_deadline(&env);
+    client.execute_proposal(&admin, &0);
+    assert_eq!(
+        client.try_execute_proposal(&admin, &0),
+        Err(Ok(Error::ProposalAlreadyExecuted))
+    );
+}
+
+#[test]
+fn test_execute_rejects_nonexistent_proposal() {
+    let env = Env::default();
+    let (admin, _, client) = setup(&env);
+    assert_eq!(
+        client.try_execute_proposal(&admin, &99),
+        Err(Ok(Error::ProposalNotFound))
+    );
+}
+
+// ── cancel_proposal ───────────────────────────────────────────────────────────
+
+#[test]
+fn test_cancel_by_admin_succeeds() {
+    let env = Env::default();
+    let (admin, _, client) = setup(&env);
+    client.propose(&admin, &ProposalAction::SetFee(400));
+    client.cancel_proposal(&admin, &0);
+    let p = client.get_proposal(&0).unwrap();
+    assert_eq!(p.status, ProposalStatus::Canceled);
+}
+
+#[test]
+fn test_cancel_by_proposer_succeeds() {
+    let env = Env::default();
+    let (admin, _, client) = setup(&env);
+    let voter = Address::generate(&env);
+    client.add_voter(&admin, &voter);
+    client.propose(&voter, &ProposalAction::SetFee(400));
+    client.cancel_proposal(&voter, &0);
+    let p = client.get_proposal(&0).unwrap();
+    assert_eq!(p.status, ProposalStatus::Canceled);
+}
+
+#[test]
+fn test_cancel_rejects_stranger() {
+    let env = Env::default();
+    let (admin, _, client) = setup(&env);
+    client.propose(&admin, &ProposalAction::SetFee(400));
+    let stranger = Address::generate(&env);
+    assert_eq!(
+        client.try_cancel_proposal(&stranger, &0),
+        Err(Ok(Error::Unauthorized))
+    );
+}
+
+#[test]
+fn test_cancel_prevents_execution() {
+    let env = Env::default();
+    let (admin, _, client) = setup(&env);
+    let voter = Address::generate(&env);
+    client.add_voter(&admin, &voter);
+    client.propose(&admin, &ProposalAction::SetFee(400));
+    client.vote(&voter, &0, &true);
+    client.cancel_proposal(&admin, &0);
+    advance_past_deadline(&env);
+    assert_eq!(
+        client.try_execute_proposal(&admin, &0),
+        Err(Ok(Error::ProposalAlreadyExecuted))
+    );
+}
+
+// ── active games unaffected by governance execution ───────────────────────────
+
+#[test]
+fn test_governance_fee_change_does_not_reprice_active_game() {
+    let env = Env::default();
+    let (admin, contract_id, client) = setup(&env);
+
+    // Fund reserves and start a game
+    env.as_contract(&contract_id, || {
+        let mut stats = CoinflipContract::load_stats(&env);
+        stats.reserve_balance = 1_000_000_000;
+        CoinflipContract::save_stats(&env, &stats);
+    });
+
+    let player = Address::generate(&env);
+    let secret = soroban_sdk::Bytes::from_slice(&env, &[1u8; 32]);
+    let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
+    client.start_game(&player, &Side::Heads, &10_000_000, &commitment);
+
+    // Governance changes fee to 500 bps
+    let voter = Address::generate(&env);
+    client.add_voter(&admin, &voter);
+    client.propose(&admin, &ProposalAction::SetFee(500));
+    client.vote(&voter, &0, &true);
+    advance_past_deadline(&env);
+    client.execute_proposal(&admin, &0);
+    assert_eq!(client.get_config().fee_bps, 500);
+
+    // The in-flight game still uses the original fee snapshot (300 bps)
+    let game: GameState = env.as_contract(&contract_id, || {
+        CoinflipContract::load_player_game(&env, &player).unwrap().unwrap()
+    });
+    assert_eq!(game.fee_bps, 300, "active game fee snapshot must be unchanged");
+}

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -55,6 +55,7 @@ use soroban_sdk::{contract, contractimpl, contracttype, contracterror, token, Ad
 /// | 30   | `Unauthorized`               | Admin          | `set_paused`, `set_treasury`, `set_wager_limits`, `set_fee` |
 /// | 31   | `InvalidFeePercentage`       | Admin          | `initialize`, `set_fee`            |
 /// | 32   | `InvalidWagerLimits`         | Admin          | `initialize`, `set_wager_limits`   |
+/// | 33   | `InvalidMultipliers`         | Admin          | `initialize`, `set_multipliers`    |
 /// | 40   | `TransferFailed`             | Transfer       | `claim_winnings`                   |
 /// | 50   | `AdminTreasuryConflict`      | Initialization | `initialize`                       |
 /// | 51   | `AlreadyInitialized`         | Initialization | `initialize`                       |
@@ -80,6 +81,7 @@ pub mod error_codes {
     pub const UNAUTHORIZED: u32 = 30;
     pub const INVALID_FEE_PERCENTAGE: u32 = 31;
     pub const INVALID_WAGER_LIMITS: u32 = 32;
+    pub const INVALID_MULTIPLIERS: u32 = 33;
 
     // Transfer errors (40)
     pub const TRANSFER_FAILED: u32 = 40;
@@ -89,7 +91,7 @@ pub mod error_codes {
     pub const ALREADY_INITIALIZED: u32 = 51;
 
     /// Total number of defined error variants.
-    pub const VARIANT_COUNT: usize = 17;
+    pub const VARIANT_COUNT: usize = 18;
 }
 
 /// Error codes for the coinflip contract.
@@ -188,6 +190,12 @@ pub enum Error {
     /// Code: 32 — see [`error_codes::INVALID_WAGER_LIMITS`]
     InvalidWagerLimits = 32,
 
+    /// Multiplier tiers are invalid (not strictly monotonically increasing,
+    /// or any tier is at or below 1x / 10_000 bps).
+    /// Returned by: `initialize`, `set_multipliers`.
+    /// Code: 33 — see [`error_codes::INVALID_MULTIPLIERS`]
+    InvalidMultipliers = 33,
+
     // ── Transfer errors (40) ────────────────────────────────────────────────
 
     /// Token transfer failed during settlement.
@@ -276,6 +284,9 @@ pub struct GameState {
     pub phase: GamePhase,
     /// Ledger sequence at game creation; used for timeout enforcement.
     pub start_ledger: u32,
+    /// Multiplier snapshot captured at `start_game`; used for all payout
+    /// and solvency calculations so admin changes don't reprice active games.
+    pub multipliers: MultiplierConfig,
 }
 
 /// Contract-wide configuration stored in persistent storage under [`StorageKey::Config`].
@@ -301,6 +312,8 @@ pub struct ContractConfig {
     pub max_wager: i128,
     /// Emergency pause flag; when `true`, `start_game` is rejected.
     pub paused: bool,
+    /// Multiplier tier configuration; snapshotted into each new game.
+    pub multipliers: MultiplierConfig,
 }
 
 /// Aggregate statistics stored in persistent storage under [`StorageKey::Stats`].
@@ -379,6 +392,137 @@ pub enum StorageKey {
     PlayerGame(Address),
     /// Per-player game history ring-buffer ([`Vec<HistoryEntry>`]), keyed by player address.
     PlayerHistory(Address),
+}
+
+/// Multiplier tier configuration, stored in [`ContractConfig`] and snapshotted
+/// into [`GameState`] at `start_game` time so admin changes never reprice
+/// in-flight games.
+///
+/// All values are in basis points (10_000 = 1x).
+/// Monotonicity invariant: `streak1 < streak2 < streak3 < streak4_plus`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MultiplierConfig {
+    /// Multiplier for streak 1 (default 19_000 = 1.9x).
+    pub streak1: u32,
+    /// Multiplier for streak 2 (default 35_000 = 3.5x).
+    pub streak2: u32,
+    /// Multiplier for streak 3 (default 60_000 = 6.0x).
+    pub streak3: u32,
+    /// Multiplier for streak 4+ (default 100_000 = 10.0x).
+    pub streak4_plus: u32,
+}
+
+impl MultiplierConfig {
+    /// Returns the default multiplier configuration matching the original constants.
+    pub fn default_config() -> Self {
+        MultiplierConfig {
+            streak1:      MULTIPLIER_STREAK_1,
+            streak2:      MULTIPLIER_STREAK_2,
+            streak3:      MULTIPLIER_STREAK_3,
+            streak4_plus: MULTIPLIER_STREAK_4_PLUS,
+        }
+    }
+
+    /// Returns the multiplier for the given streak level.
+    pub fn for_streak(&self, streak: u32) -> u32 {
+        match streak {
+            1 => self.streak1,
+            2 => self.streak2,
+            3 => self.streak3,
+            _ => self.streak4_plus,
+        }
+    }
+
+    /// Returns `true` if the tiers are strictly monotonically increasing and
+    /// all values are above 1x (10_000 bps).
+    pub fn is_valid(&self) -> bool {
+        self.streak1 > 10_000
+            && self.streak1 < self.streak2
+            && self.streak2 < self.streak3
+            && self.streak3 < self.streak4_plus
+    }
+}
+
+// ── Event payload types ─────────────────────────────────────────────────────
+//
+// Each `#[contracttype]` struct is the data payload for one event category.
+// Topics are `(Symbol("tossd"), Symbol("<action>"))` pairs so indexers can
+// filter by contract + action without decoding the full payload.
+
+/// Emitted once by `initialize`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EventInitialized {
+    pub admin:     Address,
+    pub treasury:  Address,
+    pub token:     Address,
+    pub fee_bps:   u32,
+    pub min_wager: i128,
+    pub max_wager: i128,
+}
+
+/// Emitted by `start_game` on success.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EventGameStarted {
+    pub player:     Address,
+    pub side:       Side,
+    pub wager:      i128,
+    pub commitment: BytesN<32>,
+    pub ledger:     u32,
+}
+
+/// Emitted by `reveal` on both win and loss paths.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EventGameRevealed {
+    pub player:  Address,
+    pub won:     bool,
+    /// Post-reveal streak (0 on loss).
+    pub streak:  u32,
+    pub outcome: Side,
+}
+
+/// Emitted by `cash_out` and `claim_winnings` on success.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EventGameSettled {
+    pub player: Address,
+    pub payout: i128,
+    pub fee:    i128,
+    pub streak: u32,
+    /// `Symbol("cash_out")` or `Symbol("claim_winnings")`.
+    pub method: soroban_sdk::Symbol,
+}
+
+/// Emitted by `continue_streak` on success.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EventStreakContinued {
+    pub player:         Address,
+    pub streak:         u32,
+    pub new_commitment: BytesN<32>,
+}
+
+/// Emitted by `reclaim_wager` on success.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EventWagerReclaimed {
+    pub player: Address,
+    pub wager:  i128,
+    pub ledger: u32,
+}
+
+/// Emitted by all admin setter functions (`set_paused`, `set_treasury`,
+/// `set_wager_limits`, `set_fee`).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EventAdminAction {
+    /// `Symbol("set_paused")`, `Symbol("set_treasury")`,
+    /// `Symbol("set_wager_limits")`, or `Symbol("set_fee")`.
+    pub action: soroban_sdk::Symbol,
+    pub admin:  Address,
 }
 
 /// Multiplier values in basis points (1 bps = 0.0001x).
@@ -615,6 +759,7 @@ impl CoinflipContract {
             min_wager,
             max_wager,
             paused: false,
+            multipliers: MultiplierConfig::default_config(),
         };
         
         let stats = ContractStats {
@@ -807,7 +952,7 @@ impl CoinflipContract {
         // Guard 5: reserves must cover the worst-case payout (streak 4+, no fee deduction)
         let stats = Self::load_stats(&env);
         let max_payout = wager
-            .checked_mul(MULTIPLIER_STREAK_4_PLUS as i128)
+            .checked_mul(config.multipliers.streak4_plus as i128)
             .and_then(|v| v.checked_div(10_000))
             .ok_or(Error::InsufficientReserves)?;
         if stats.reserve_balance < max_payout {
@@ -829,6 +974,7 @@ impl CoinflipContract {
             fee_bps: config.fee_bps,
             phase: GamePhase::Committed,
             start_ledger: env.ledger().sequence(),
+            multipliers: config.multipliers,
         };
 
         Self::save_player_game(&env, &player, &game);
@@ -1003,12 +1149,17 @@ impl CoinflipContract {
         let config = Self::load_config(&env);
         let token_client = token::Client::new(&env, &config.token);
 
-        // Single-pass payout breakdown: gross, fee, and net computed together to
-        // avoid the duplicate multiplier lookup + two checked_div calls that would
-        // result from calling calculate_payout and then recomputing gross/fee.
-        let (gross_payout, fee_amount, net_payout) =
-            calculate_payout_breakdown(game.wager, game.streak, game.fee_bps)
-                .ok_or(Error::InsufficientReserves)?;
+        // Single-pass payout breakdown using the snapshotted multiplier so that
+        // admin changes to multipliers never reprice in-flight games.
+        let multiplier_bps = game.multipliers.for_streak(game.streak) as i128;
+        let gross_payout = game.wager.checked_mul(multiplier_bps)
+            .and_then(|v| v.checked_div(10_000))
+            .ok_or(Error::InsufficientReserves)?;
+        let fee_amount = gross_payout.checked_mul(game.fee_bps as i128)
+            .and_then(|v| v.checked_div(10_000))
+            .ok_or(Error::InsufficientReserves)?;
+        let net_payout = gross_payout.checked_sub(fee_amount)
+            .ok_or(Error::InsufficientReserves)?;
 
         // Check sufficient reserves
         let stats = Self::load_stats(&env);
@@ -1078,12 +1229,17 @@ impl CoinflipContract {
             return Err(Error::NoWinningsToClaimOrContinue);
         }
 
-        // Single-pass payout breakdown: gross, fee, and net computed together to
-        // avoid the duplicate multiplier lookup + two checked_div calls that would
-        // result from calling calculate_payout and then recomputing gross/fee.
-        let (gross, fee, net_payout) =
-            calculate_payout_breakdown(game.wager, game.streak, game.fee_bps)
-                .ok_or(Error::InsufficientReserves)?;
+        // Single-pass payout breakdown using the snapshotted multiplier so that
+        // admin changes to multipliers never reprice in-flight games.
+        let multiplier_bps = game.multipliers.for_streak(game.streak) as i128;
+        let gross = game.wager.checked_mul(multiplier_bps)
+            .and_then(|v| v.checked_div(10_000))
+            .ok_or(Error::InsufficientReserves)?;
+        let fee = gross.checked_mul(game.fee_bps as i128)
+            .and_then(|v| v.checked_div(10_000))
+            .ok_or(Error::InsufficientReserves)?;
+        let net_payout = gross.checked_sub(fee)
+            .ok_or(Error::InsufficientReserves)?;
 
         let mut stats = Self::load_stats(&env);
         stats.reserve_balance = stats.reserve_balance
@@ -1219,7 +1375,7 @@ impl CoinflipContract {
 
         let next_streak = game.streak.saturating_add(1);
         let max_payout = game.wager
-            .checked_mul(get_multiplier(next_streak) as i128)
+            .checked_mul(game.multipliers.for_streak(next_streak) as i128)
             .and_then(|v| v.checked_div(10_000))
             .ok_or(Error::InsufficientReserves)?;
 
@@ -1389,6 +1545,57 @@ impl CoinflipContract {
 
         config.fee_bps = fee_bps;
         Self::save_config(&env, &config);
+
+        Ok(())
+    }
+
+    /// Update the multiplier tiers used for payout calculations.
+    ///
+    /// Only the configured `admin` may call this function.
+    /// Changes apply to games created **after** this call; in-flight games
+    /// use the multipliers snapshotted at `start_game` time.
+    ///
+    /// # Monotonicity invariant
+    /// `streak1 < streak2 < streak3 < streak4_plus` and all values > 10_000 (1x).
+    ///
+    /// # Arguments
+    /// - `admin`       – must match `config.admin`; authorization required
+    /// - `streak1`     – multiplier for streak 1 in bps (e.g. 19_000 = 1.9x)
+    /// - `streak2`     – multiplier for streak 2 in bps
+    /// - `streak3`     – multiplier for streak 3 in bps
+    /// - `streak4_plus`– multiplier for streak 4+ in bps
+    ///
+    /// # Errors
+    /// - [`Error::Unauthorized`]       – caller is not the configured admin
+    /// - [`Error::InvalidMultipliers`] – tiers are not strictly monotonically
+    ///                                   increasing or any value is ≤ 10_000
+    pub fn set_multipliers(
+        env: Env,
+        admin: Address,
+        streak1: u32,
+        streak2: u32,
+        streak3: u32,
+        streak4_plus: u32,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+
+        let mut config = Self::load_config(&env);
+        if admin != config.admin {
+            return Err(Error::Unauthorized);
+        }
+
+        let m = MultiplierConfig { streak1, streak2, streak3, streak4_plus };
+        if !m.is_valid() {
+            return Err(Error::InvalidMultipliers);
+        }
+
+        config.multipliers = m;
+        Self::save_config(&env, &config);
+
+        Self::emit_admin_action(&env, EventAdminAction {
+            action: Symbol::new(&env, "set_multipliers"),
+            admin,
+        });
 
         Ok(())
     }
@@ -1925,15 +2132,10 @@ mod tests {
             // Force a win by setting game state directly
             env.as_contract(&contract_id, || {
                 let mut game = GameState {
-                    wager,
-                    side: Side::Heads,
-                    streak: 1,
-                    commitment,
-                    contract_random: env.crypto().sha256(&Bytes::from_slice(env, &[2u8; 32])).into(),
-                    fee_bps,
-                    phase: GamePhase::Revealed,
-                    start_ledger: 0,
-                };
+                            $$$
+                            start_ledger: 0,
+                            multipliers: MultiplierConfig::default_config(),
+                        };
                 CoinflipContract::save_player_game(env, &player, &game);
             });
         }
@@ -2127,15 +2329,10 @@ mod tests {
     ) {
         let dummy = dummy_commitment(env);
         let game = GameState {
-            wager,
-            side: Side::Heads,
-            streak,
-            commitment: dummy.clone(),
-            contract_random: dummy,
-            fee_bps: 300,
-            phase,
-            start_ledger: 0,
-        };
+                    $$$
+                    start_ledger: 0,
+                    multipliers: MultiplierConfig::default_config(),
+                };
         env.as_contract(contract_id, || {
             CoinflipContract::save_player_game(env, player, &game);
         });
@@ -2836,15 +3033,10 @@ mod tests {
         // Inject directly so we bypass start_game's own reserve check.
         env.as_contract(&contract_id, || {
             let game = GameState {
-                wager: 10_000_000,
-                side: Side::Heads,
-                streak: 1,
-                commitment: dummy_commitment(&env),
-                contract_random: dummy_commitment(&env),
-                fee_bps: 300,
-                phase: GamePhase::Revealed,
-                start_ledger: 0,
-            };
+                        $$$
+                        start_ledger: 0,
+                        multipliers: MultiplierConfig::default_config(),
+                    };
             CoinflipContract::save_player_game(&env, &player, &game);
         });
 
@@ -4411,15 +4603,10 @@ mod property_tests {
     ) {
         let dummy = dummy_commitment_prop(env);
         let game = GameState {
-            wager,
-            side: Side::Heads,
-            streak,
-            commitment: dummy.clone(),
-            contract_random: dummy,
-            fee_bps: 300,
-            phase,
-            start_ledger: 0,
-        };
+                    $$$
+                    start_ledger: 0,
+                    multipliers: MultiplierConfig::default_config(),
+                };
         env.as_contract(contract_id, || {
             CoinflipContract::save_player_game(env, player, &game);
         });
@@ -5370,15 +5557,10 @@ mod cumulative_fee_tests {
             .into();
 
         let game = GameState {
-            wager,
-            side: Side::Heads,
-            streak,
-            commitment: dummy.clone(),
-            contract_random: dummy,
-            fee_bps,
-            phase: GamePhase::Revealed,
-            start_ledger: 0,
-        };
+                    $$$
+                    start_ledger: 0,
+                    multipliers: MultiplierConfig::default_config(),
+                };
         env.as_contract(contract_id, || {
             CoinflipContract::save_player_game(env, player, &game);
         });
@@ -7267,15 +7449,10 @@ mod integration_tests {
         ) {
             let commitment = self.make_commitment(seed);
             let game = GameState {
-                wager,
-                side: Side::Heads,
-                streak,
-                commitment: commitment.clone(),
-                contract_random: commitment, // deterministic stand-in
-                fee_bps: DEFAULT_FEE_BPS,
-                phase,
-                start_ledger: 0,
-            };
+                        $$$
+                        start_ledger: 0,
+                        multipliers: MultiplierConfig::default_config(),
+                    };
             self.env.as_contract(&self.contract_id, || {
                 CoinflipContract::save_player_game(&self.env, player, &game);
             });
@@ -7845,15 +8022,10 @@ mod cash_out_availability_tests {
     ) {
         let dummy = prop_commitment(env);
         let game = GameState {
-            wager,
-            side: Side::Heads,
-            streak,
-            commitment: dummy.clone(),
-            contract_random: dummy,
-            fee_bps: 300,
-            phase,
-            start_ledger: 0,
-        };
+                    $$$
+                    start_ledger: 0,
+                    multipliers: MultiplierConfig::default_config(),
+                };
         env.as_contract(contract_id, || {
             CoinflipContract::save_player_game(env, player, &game);
         });

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -98,8 +98,11 @@ pub mod error_codes {
     pub const THRESHOLD_NOT_MET: u32 = 64;
     pub const PROPOSAL_ALREADY_EXECUTED: u32 = 65;
 
+    // RBAC errors (70)
+    pub const INSUFFICIENT_ROLE: u32 = 70;
+
     /// Total number of defined error variants.
-    pub const VARIANT_COUNT: usize = 24;
+    pub const VARIANT_COUNT: usize = 25;
 }
 
 /// Error codes for the coinflip contract.
@@ -248,6 +251,12 @@ pub enum Error {
     /// Proposal has already been executed or canceled.
     /// Code: 65
     ProposalAlreadyExecuted = 65,
+
+    // ── RBAC errors (70) ────────────────────────────────────────────────────
+
+    /// Caller holds a role that is insufficient for the requested operation.
+    /// Code: 70
+    InsufficientRole = 70,
 }
 
 /// The player's chosen side for a coinflip.
@@ -434,6 +443,35 @@ pub enum StorageKey {
     ProposalVote(u32, Address),
     /// Governance: registered voter list (`Vec<Address>`).
     Voters,
+    /// RBAC: role assigned to an address.
+    Role(Address),
+}
+
+/// Admin role levels for role-based access control.
+///
+/// Permission matrix:
+///
+/// | Operation          | SuperAdmin | ConfigAdmin | PauseAdmin |
+/// |--------------------|:----------:|:-----------:|:----------:|
+/// | grant_role         | ✓          |             |            |
+/// | revoke_role        | ✓          |             |            |
+/// | set_treasury       | ✓          |             |            |
+/// | set_wager_limits   | ✓          | ✓           |            |
+/// | set_multipliers    | ✓          | ✓           |            |
+/// | set_fee            | ✓          | ✓           |            |
+/// | set_paused         | ✓          | ✓           | ✓          |
+///
+/// `config.admin` always has implicit `SuperAdmin` authority regardless of
+/// the role stored in `StorageKey::Role`.
+#[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum Role {
+    /// Can pause/unpause the contract.
+    PauseAdmin  = 0,
+    /// Can change fee, wager limits, multipliers, and pause.
+    ConfigAdmin = 1,
+    /// Full admin: all of the above plus treasury and role management.
+    SuperAdmin  = 2,
 }
 
 /// Multiplier tier configuration, stored in [`ContractConfig`] and snapshotted
@@ -1512,9 +1550,7 @@ impl CoinflipContract {
         admin.require_auth();
 
         let mut config = Self::load_config(&env);
-        if admin != config.admin {
-            return Err(Error::Unauthorized);
-        }
+        Self::require_role(&env, &admin, Role::PauseAdmin, &config)?;
 
         config.paused = paused;
         Self::save_config(&env, &config);
@@ -1541,9 +1577,7 @@ impl CoinflipContract {
         admin.require_auth();
 
         let mut config = Self::load_config(&env);
-        if admin != config.admin {
-            return Err(Error::Unauthorized);
-        }
+        Self::require_role(&env, &admin, Role::SuperAdmin, &config)?;
 
         config.treasury = treasury;
         Self::save_config(&env, &config);
@@ -1577,9 +1611,7 @@ impl CoinflipContract {
         admin.require_auth();
 
         let mut config = Self::load_config(&env);
-        if admin != config.admin {
-            return Err(Error::Unauthorized);
-        }
+        Self::require_role(&env, &admin, Role::ConfigAdmin, &config)?;
 
         if min_wager >= max_wager {
             return Err(Error::InvalidWagerLimits);
@@ -1619,13 +1651,8 @@ impl CoinflipContract {
         admin.require_auth();
 
         let mut config = Self::load_config(&env);
+        Self::require_role(&env, &admin, Role::ConfigAdmin, &config)?;
 
-        // Guard 2: caller must be the configured admin.
-        if admin != config.admin {
-            return Err(Error::Unauthorized);
-        }
-
-        // Guard 3: fee must stay within the permitted protocol range (2–5%).
         if fee_bps < 200 || fee_bps > 500 {
             return Err(Error::InvalidFeePercentage);
         }
@@ -1667,9 +1694,7 @@ impl CoinflipContract {
         admin.require_auth();
 
         let mut config = Self::load_config(&env);
-        if admin != config.admin {
-            return Err(Error::Unauthorized);
-        }
+        Self::require_role(&env, &admin, Role::ConfigAdmin, &config)?;
 
         let m = MultiplierConfig { streak1, streak2, streak3, streak4_plus };
         if !m.is_valid() {
@@ -1732,6 +1757,51 @@ impl CoinflipContract {
         env.storage().persistent().extend_ttl(&key, TTL_THRESHOLD, TTL_EXTEND_TO);
     }
 
+    // ── RBAC helpers ────────────────────────────────────────────────────────
+
+    /// Returns the role assigned to `addr`, or `None` if no role is set.
+    /// `config.admin` always has implicit `SuperAdmin` authority.
+    fn get_role(env: &Env, addr: &Address, config: &ContractConfig) -> Option<Role> {
+        if addr == &config.admin {
+            return Some(Role::SuperAdmin);
+        }
+        env.storage().persistent().get(&StorageKey::Role(addr.clone())).unwrap()
+    }
+
+    /// Returns `Ok(())` if `caller` holds at least `required` role, else `Err(InsufficientRole)`.
+    fn require_role(env: &Env, caller: &Address, required: Role, config: &ContractConfig) -> Result<(), Error> {
+        match Self::get_role(env, caller, config) {
+            Some(role) if role >= required => Ok(()),
+            _ => Err(Error::InsufficientRole),
+        }
+    }
+
+    // ── RBAC public API ──────────────────────────────────────────────────────
+
+    /// Assign a role to `grantee`.  Only `SuperAdmin` (or `config.admin`) may call this.
+    pub fn grant_role(env: Env, caller: Address, grantee: Address, role: Role) -> Result<(), Error> {
+        caller.require_auth();
+        let config = Self::load_config(&env);
+        Self::require_role(&env, &caller, Role::SuperAdmin, &config)?;
+        env.storage().persistent().set(&StorageKey::Role(grantee), &role);
+        Ok(())
+    }
+
+    /// Remove the role from `grantee`.  Only `SuperAdmin` may call this.
+    pub fn revoke_role(env: Env, caller: Address, grantee: Address) -> Result<(), Error> {
+        caller.require_auth();
+        let config = Self::load_config(&env);
+        Self::require_role(&env, &caller, Role::SuperAdmin, &config)?;
+        env.storage().persistent().remove(&StorageKey::Role(grantee));
+        Ok(())
+    }
+
+    /// Return the role assigned to `addr`, if any.
+    pub fn get_role_of(env: Env, addr: Address) -> Option<Role> {
+        let config = Self::load_config(&env);
+        Self::get_role(&env, &addr, &config)
+    }
+
     // ── Governance public API ───────────────────────────────────────────────
 
     /// Register an address as a governance voter.
@@ -1740,9 +1810,7 @@ impl CoinflipContract {
     pub fn add_voter(env: Env, admin: Address, voter: Address) -> Result<(), Error> {
         admin.require_auth();
         let config = Self::load_config(&env);
-        if admin != config.admin {
-            return Err(Error::Unauthorized);
-        }
+        Self::require_role(&env, &admin, Role::SuperAdmin, &config)?;
         let mut voters = Self::load_voters(&env);
         // Avoid duplicates
         for i in 0..voters.len() {
@@ -1761,9 +1829,7 @@ impl CoinflipContract {
     pub fn remove_voter(env: Env, admin: Address, voter: Address) -> Result<(), Error> {
         admin.require_auth();
         let config = Self::load_config(&env);
-        if admin != config.admin {
-            return Err(Error::Unauthorized);
-        }
+        Self::require_role(&env, &admin, Role::SuperAdmin, &config)?;
         let voters = Self::load_voters(&env);
         let mut updated = soroban_sdk::Vec::new(&env);
         for i in 0..voters.len() {
@@ -2205,6 +2271,9 @@ mod admin_security_tests;
 
 #[cfg(test)]
 mod governance_tests;
+
+#[cfg(test)]
+mod rbac_tests;
 
 #[cfg(test)]
 mod tests {

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -90,8 +90,16 @@ pub mod error_codes {
     pub const ADMIN_TREASURY_CONFLICT: u32 = 50;
     pub const ALREADY_INITIALIZED: u32 = 51;
 
+    // Governance errors (60–65)
+    pub const PROPOSAL_NOT_FOUND: u32 = 60;
+    pub const ALREADY_VOTED: u32 = 61;
+    pub const VOTING_OPEN: u32 = 62;
+    pub const VOTING_CLOSED: u32 = 63;
+    pub const THRESHOLD_NOT_MET: u32 = 64;
+    pub const PROPOSAL_ALREADY_EXECUTED: u32 = 65;
+
     /// Total number of defined error variants.
-    pub const VARIANT_COUNT: usize = 18;
+    pub const VARIANT_COUNT: usize = 24;
 }
 
 /// Error codes for the coinflip contract.
@@ -214,6 +222,32 @@ pub enum Error {
     /// Returned by: `initialize`.
     /// Code: 51 — see [`error_codes::ALREADY_INITIALIZED`]
     AlreadyInitialized = 51,
+
+    // ── Governance errors (60–65) ───────────────────────────────────────────
+
+    /// No proposal exists with the given id.
+    /// Code: 60
+    ProposalNotFound = 60,
+
+    /// Caller has already cast a vote on this proposal.
+    /// Code: 61
+    AlreadyVoted = 61,
+
+    /// Action requires voting to be closed but it is still open.
+    /// Code: 62
+    VotingOpen = 62,
+
+    /// Action requires voting to be open but the deadline has passed.
+    /// Code: 63
+    VotingClosed = 63,
+
+    /// Proposal did not reach the required approval threshold.
+    /// Code: 64
+    ThresholdNotMet = 64,
+
+    /// Proposal has already been executed or canceled.
+    /// Code: 65
+    ProposalAlreadyExecuted = 65,
 }
 
 /// The player's chosen side for a coinflip.
@@ -392,6 +426,14 @@ pub enum StorageKey {
     PlayerGame(Address),
     /// Per-player game history ring-buffer ([`Vec<HistoryEntry>`]), keyed by player address.
     PlayerHistory(Address),
+    /// Governance: monotonically increasing proposal counter.
+    ProposalCount,
+    /// Governance: a single [`Proposal`] keyed by its `u32` id.
+    Proposal(u32),
+    /// Governance: whether `voter` has already voted on proposal `id`.
+    ProposalVote(u32, Address),
+    /// Governance: registered voter list (`Vec<Address>`).
+    Voters,
 }
 
 /// Multiplier tier configuration, stored in [`ContractConfig`] and snapshotted
@@ -443,6 +485,51 @@ impl MultiplierConfig {
             && self.streak3 < self.streak4_plus
     }
 }
+
+// ── Governance types ────────────────────────────────────────────────────────
+
+/// The configuration change a proposal requests.
+///
+/// Each variant maps 1-to-1 to an existing admin setter so that executing a
+/// proposal is identical to calling that setter directly.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ProposalAction {
+    SetFee(u32),
+    SetWagerLimits(i128, i128),
+    SetMultipliers(MultiplierConfig),
+    SetPaused(bool),
+    SetTreasury(Address),
+}
+
+/// Lifecycle state of a governance proposal.
+#[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ProposalStatus {
+    /// Voting window is open.
+    Active,
+    /// Executed successfully.
+    Executed,
+    /// Canceled by the admin before execution.
+    Canceled,
+}
+
+/// A governance proposal stored under [`StorageKey::Proposal`].
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Proposal {
+    pub id:              u32,
+    pub proposer:        Address,
+    pub action:          ProposalAction,
+    /// Ledger sequence after which voting is closed.
+    pub deadline_ledger: u32,
+    pub votes_for:       u32,
+    pub votes_against:   u32,
+    pub status:          ProposalStatus,
+}
+
+/// Number of ledgers a proposal's voting window stays open (~24 h at 5 s/ledger).
+pub const VOTING_PERIOD_LEDGERS: u32 = 17_280;
 
 // ── Event payload types ─────────────────────────────────────────────────────
 //
@@ -1600,6 +1687,279 @@ impl CoinflipContract {
         Ok(())
     }
 
+    // ── Governance helpers ──────────────────────────────────────────────────
+
+    fn load_proposal_count(env: &Env) -> u32 {
+        env.storage().persistent()
+            .get(&StorageKey::ProposalCount)
+            .unwrap_or(Some(0u32))
+            .unwrap_or(0)
+    }
+
+    fn save_proposal(env: &Env, p: &Proposal) {
+        let key = StorageKey::Proposal(p.id);
+        env.storage().persistent().set(&key, p);
+        env.storage().persistent().extend_ttl(&key, TTL_THRESHOLD, TTL_EXTEND_TO);
+    }
+
+    fn load_proposal(env: &Env, id: u32) -> Option<Proposal> {
+        let key = StorageKey::Proposal(id);
+        if env.storage().persistent().has(&key) {
+            env.storage().persistent().extend_ttl(&key, TTL_THRESHOLD, TTL_EXTEND_TO);
+        }
+        env.storage().persistent().get(&key).unwrap()
+    }
+
+    fn load_voters(env: &Env) -> soroban_sdk::Vec<Address> {
+        env.storage().persistent()
+            .get(&StorageKey::Voters)
+            .unwrap_or_else(|| soroban_sdk::Vec::new(env))
+    }
+
+    fn save_voters(env: &Env, voters: &soroban_sdk::Vec<Address>) {
+        env.storage().persistent().set(&StorageKey::Voters, voters);
+        env.storage().persistent().extend_ttl(&StorageKey::Voters, TTL_THRESHOLD, TTL_EXTEND_TO);
+    }
+
+    fn has_voted(env: &Env, proposal_id: u32, voter: &Address) -> bool {
+        env.storage().persistent()
+            .has(&StorageKey::ProposalVote(proposal_id, voter.clone()))
+    }
+
+    fn record_vote(env: &Env, proposal_id: u32, voter: &Address) {
+        let key = StorageKey::ProposalVote(proposal_id, voter.clone());
+        env.storage().persistent().set(&key, &true);
+        env.storage().persistent().extend_ttl(&key, TTL_THRESHOLD, TTL_EXTEND_TO);
+    }
+
+    // ── Governance public API ───────────────────────────────────────────────
+
+    /// Register an address as a governance voter.
+    ///
+    /// Only the admin may call this.  Duplicate registrations are silently ignored.
+    pub fn add_voter(env: Env, admin: Address, voter: Address) -> Result<(), Error> {
+        admin.require_auth();
+        let config = Self::load_config(&env);
+        if admin != config.admin {
+            return Err(Error::Unauthorized);
+        }
+        let mut voters = Self::load_voters(&env);
+        // Avoid duplicates
+        for i in 0..voters.len() {
+            if voters.get(i).unwrap() == voter {
+                return Ok(());
+            }
+        }
+        voters.push_back(voter);
+        Self::save_voters(&env, &voters);
+        Ok(())
+    }
+
+    /// Remove an address from the governance voter list.
+    ///
+    /// Only the admin may call this.
+    pub fn remove_voter(env: Env, admin: Address, voter: Address) -> Result<(), Error> {
+        admin.require_auth();
+        let config = Self::load_config(&env);
+        if admin != config.admin {
+            return Err(Error::Unauthorized);
+        }
+        let voters = Self::load_voters(&env);
+        let mut updated = soroban_sdk::Vec::new(&env);
+        for i in 0..voters.len() {
+            let v = voters.get(i).unwrap();
+            if v != voter {
+                updated.push_back(v);
+            }
+        }
+        Self::save_voters(&env, &updated);
+        Ok(())
+    }
+
+    /// Create a governance proposal for a configuration change.
+    ///
+    /// Any registered voter or the admin may propose.
+    /// Returns the new proposal id.
+    pub fn propose(env: Env, proposer: Address, action: ProposalAction) -> Result<u32, Error> {
+        proposer.require_auth();
+
+        // Proposer must be admin or a registered voter.
+        let config = Self::load_config(&env);
+        let voters = Self::load_voters(&env);
+        let is_admin = proposer == config.admin;
+        let is_voter = (0..voters.len()).any(|i| voters.get(i).unwrap() == proposer);
+        if !is_admin && !is_voter {
+            return Err(Error::Unauthorized);
+        }
+
+        let id = Self::load_proposal_count(&env);
+        let proposal = Proposal {
+            id,
+            proposer,
+            action,
+            deadline_ledger: env.ledger().sequence().saturating_add(VOTING_PERIOD_LEDGERS),
+            votes_for: 0,
+            votes_against: 0,
+            status: ProposalStatus::Active,
+        };
+
+        Self::save_proposal(&env, &proposal);
+        env.storage().persistent().set(&StorageKey::ProposalCount, &(id + 1));
+        env.storage().persistent().extend_ttl(&StorageKey::ProposalCount, TTL_THRESHOLD, TTL_EXTEND_TO);
+
+        Ok(id)
+    }
+
+    /// Cast a vote on an active proposal.
+    ///
+    /// - `approve = true`  → vote in favour
+    /// - `approve = false` → vote against
+    ///
+    /// Only registered voters may vote.  Each voter may vote at most once per proposal.
+    pub fn vote(env: Env, voter: Address, proposal_id: u32, approve: bool) -> Result<(), Error> {
+        voter.require_auth();
+
+        // Must be a registered voter.
+        let voters = Self::load_voters(&env);
+        let is_voter = (0..voters.len()).any(|i| voters.get(i).unwrap() == voter);
+        if !is_voter {
+            return Err(Error::Unauthorized);
+        }
+
+        let mut proposal = Self::load_proposal(&env, proposal_id)
+            .ok_or(Error::ProposalNotFound)?;
+
+        if proposal.status != ProposalStatus::Active {
+            return Err(Error::ProposalAlreadyExecuted);
+        }
+        if env.ledger().sequence() > proposal.deadline_ledger {
+            return Err(Error::VotingClosed);
+        }
+        if Self::has_voted(&env, proposal_id, &voter) {
+            return Err(Error::AlreadyVoted);
+        }
+
+        if approve {
+            proposal.votes_for = proposal.votes_for.saturating_add(1);
+        } else {
+            proposal.votes_against = proposal.votes_against.saturating_add(1);
+        }
+
+        Self::record_vote(&env, proposal_id, &voter);
+        Self::save_proposal(&env, &proposal);
+
+        Ok(())
+    }
+
+    /// Execute a proposal that has passed the voting threshold.
+    ///
+    /// Execution is allowed only after the voting deadline has passed and
+    /// `votes_for > 50%` of registered voters (minimum 1 vote).
+    pub fn execute_proposal(env: Env, caller: Address, proposal_id: u32) -> Result<(), Error> {
+        caller.require_auth();
+
+        // Only admin or a registered voter may trigger execution.
+        let config = Self::load_config(&env);
+        let voters = Self::load_voters(&env);
+        let is_admin = caller == config.admin;
+        let is_voter = (0..voters.len()).any(|i| voters.get(i).unwrap() == caller);
+        if !is_admin && !is_voter {
+            return Err(Error::Unauthorized);
+        }
+
+        let mut proposal = Self::load_proposal(&env, proposal_id)
+            .ok_or(Error::ProposalNotFound)?;
+
+        if proposal.status != ProposalStatus::Active {
+            return Err(Error::ProposalAlreadyExecuted);
+        }
+        if env.ledger().sequence() <= proposal.deadline_ledger {
+            return Err(Error::VotingOpen);
+        }
+
+        // 51% threshold: votes_for must be > half of registered voters, minimum 1.
+        let total_voters = voters.len();
+        let threshold = total_voters / 2 + 1; // integer ceiling of 51%
+        if proposal.votes_for < threshold || proposal.votes_for == 0 {
+            return Err(Error::ThresholdNotMet);
+        }
+
+        // Apply the configuration change.
+        let mut cfg = Self::load_config(&env);
+        match proposal.action.clone() {
+            ProposalAction::SetFee(fee_bps) => {
+                if fee_bps < 200 || fee_bps > 500 {
+                    return Err(Error::InvalidFeePercentage);
+                }
+                cfg.fee_bps = fee_bps;
+            }
+            ProposalAction::SetWagerLimits(min_wager, max_wager) => {
+                if min_wager >= max_wager {
+                    return Err(Error::InvalidWagerLimits);
+                }
+                cfg.min_wager = min_wager;
+                cfg.max_wager = max_wager;
+            }
+            ProposalAction::SetMultipliers(m) => {
+                if !m.is_valid() {
+                    return Err(Error::InvalidMultipliers);
+                }
+                cfg.multipliers = m;
+            }
+            ProposalAction::SetPaused(paused) => {
+                cfg.paused = paused;
+            }
+            ProposalAction::SetTreasury(treasury) => {
+                cfg.treasury = treasury;
+            }
+        }
+        Self::save_config(&env, &cfg);
+
+        proposal.status = ProposalStatus::Executed;
+        Self::save_proposal(&env, &proposal);
+
+        Self::emit_admin_action(&env, EventAdminAction {
+            action: Symbol::new(&env, "gov_execute"),
+            admin: caller,
+        });
+
+        Ok(())
+    }
+
+    /// Cancel an active proposal before it is executed.
+    ///
+    /// Only the admin or the original proposer may cancel.
+    pub fn cancel_proposal(env: Env, caller: Address, proposal_id: u32) -> Result<(), Error> {
+        caller.require_auth();
+
+        let mut proposal = Self::load_proposal(&env, proposal_id)
+            .ok_or(Error::ProposalNotFound)?;
+
+        if proposal.status != ProposalStatus::Active {
+            return Err(Error::ProposalAlreadyExecuted);
+        }
+
+        let config = Self::load_config(&env);
+        if caller != config.admin && caller != proposal.proposer {
+            return Err(Error::Unauthorized);
+        }
+
+        proposal.status = ProposalStatus::Canceled;
+        Self::save_proposal(&env, &proposal);
+
+        Ok(())
+    }
+
+    /// Return a proposal by id.
+    pub fn get_proposal(env: Env, proposal_id: u32) -> Option<Proposal> {
+        Self::load_proposal(&env, proposal_id)
+    }
+
+    /// Return the registered voter list.
+    pub fn get_voters(env: Env) -> soroban_sdk::Vec<Address> {
+        Self::load_voters(&env)
+    }
+
     /// Reclaim a wager from a game that has exceeded the reveal timeout.
     ///
     /// If a player starts a game but never calls `reveal`, their wager is
@@ -1842,6 +2202,9 @@ mod statistics_tests;
 
 #[cfg(test)]
 mod admin_security_tests;
+
+#[cfg(test)]
+mod governance_tests;
 
 #[cfg(test)]
 mod tests {

--- a/contract/src/rbac_tests.rs
+++ b/contract/src/rbac_tests.rs
@@ -1,0 +1,265 @@
+//! # RBAC Tests
+//!
+//! Verifies role-based access control for all admin operations.
+
+use super::*;
+use soroban_sdk::testutils::Address as _;
+
+fn setup(env: &Env) -> (Address, CoinflipContractClient) {
+    env.mock_all_auths();
+    let contract_id = env.register(CoinflipContract, ());
+    let client = CoinflipContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    let treasury = Address::generate(env);
+    let token = Address::generate(env);
+    client.initialize(&admin, &treasury, &token, &300, &1_000_000, &100_000_000);
+    (admin, client)
+}
+
+// ── grant_role / revoke_role ──────────────────────────────────────────────────
+
+#[test]
+fn test_grant_role_by_super_admin() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+    let grantee = Address::generate(&env);
+    assert!(client.try_grant_role(&admin, &grantee, &Role::ConfigAdmin).is_ok());
+    assert_eq!(client.get_role_of(&grantee), Some(Role::ConfigAdmin));
+}
+
+#[test]
+fn test_grant_role_rejected_for_non_super_admin() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+    let config_admin = Address::generate(&env);
+    client.grant_role(&admin, &config_admin, &Role::ConfigAdmin);
+
+    let target = Address::generate(&env);
+    // ConfigAdmin cannot grant roles
+    assert_eq!(
+        client.try_grant_role(&config_admin, &target, &Role::PauseAdmin),
+        Err(Ok(Error::InsufficientRole))
+    );
+}
+
+#[test]
+fn test_revoke_role_by_super_admin() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+    let grantee = Address::generate(&env);
+    client.grant_role(&admin, &grantee, &Role::PauseAdmin);
+    client.revoke_role(&admin, &grantee);
+    assert_eq!(client.get_role_of(&grantee), None);
+}
+
+#[test]
+fn test_revoke_role_rejected_for_non_super_admin() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+    let pause_admin = Address::generate(&env);
+    client.grant_role(&admin, &pause_admin, &Role::PauseAdmin);
+    assert_eq!(
+        client.try_revoke_role(&pause_admin, &pause_admin),
+        Err(Ok(Error::InsufficientRole))
+    );
+}
+
+#[test]
+fn test_config_admin_implicit_super_admin() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+    // config.admin always has SuperAdmin without an explicit grant
+    assert_eq!(client.get_role_of(&admin), Some(Role::SuperAdmin));
+}
+
+// ── set_paused (PauseAdmin+) ──────────────────────────────────────────────────
+
+#[test]
+fn test_set_paused_allowed_for_pause_admin() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+    let pause_admin = Address::generate(&env);
+    client.grant_role(&admin, &pause_admin, &Role::PauseAdmin);
+    assert!(client.try_set_paused(&pause_admin, &true).is_ok());
+    assert!(client.get_config().paused);
+}
+
+#[test]
+fn test_set_paused_allowed_for_config_admin() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+    let config_admin = Address::generate(&env);
+    client.grant_role(&admin, &config_admin, &Role::ConfigAdmin);
+    assert!(client.try_set_paused(&config_admin, &true).is_ok());
+}
+
+#[test]
+fn test_set_paused_allowed_for_super_admin() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+    assert!(client.try_set_paused(&admin, &true).is_ok());
+}
+
+#[test]
+fn test_set_paused_rejected_for_no_role() {
+    let env = Env::default();
+    let (_, client) = setup(&env);
+    let stranger = Address::generate(&env);
+    assert_eq!(
+        client.try_set_paused(&stranger, &true),
+        Err(Ok(Error::InsufficientRole))
+    );
+}
+
+// ── set_fee (ConfigAdmin+) ────────────────────────────────────────────────────
+
+#[test]
+fn test_set_fee_allowed_for_config_admin() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+    let config_admin = Address::generate(&env);
+    client.grant_role(&admin, &config_admin, &Role::ConfigAdmin);
+    assert!(client.try_set_fee(&config_admin, &400).is_ok());
+    assert_eq!(client.get_config().fee_bps, 400);
+}
+
+#[test]
+fn test_set_fee_rejected_for_pause_admin() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+    let pause_admin = Address::generate(&env);
+    client.grant_role(&admin, &pause_admin, &Role::PauseAdmin);
+    assert_eq!(
+        client.try_set_fee(&pause_admin, &400),
+        Err(Ok(Error::InsufficientRole))
+    );
+}
+
+#[test]
+fn test_set_fee_rejected_for_no_role() {
+    let env = Env::default();
+    let (_, client) = setup(&env);
+    let stranger = Address::generate(&env);
+    assert_eq!(
+        client.try_set_fee(&stranger, &400),
+        Err(Ok(Error::InsufficientRole))
+    );
+}
+
+// ── set_wager_limits (ConfigAdmin+) ──────────────────────────────────────────
+
+#[test]
+fn test_set_wager_limits_allowed_for_config_admin() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+    let config_admin = Address::generate(&env);
+    client.grant_role(&admin, &config_admin, &Role::ConfigAdmin);
+    assert!(client.try_set_wager_limits(&config_admin, &2_000_000, &200_000_000).is_ok());
+}
+
+#[test]
+fn test_set_wager_limits_rejected_for_pause_admin() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+    let pause_admin = Address::generate(&env);
+    client.grant_role(&admin, &pause_admin, &Role::PauseAdmin);
+    assert_eq!(
+        client.try_set_wager_limits(&pause_admin, &2_000_000, &200_000_000),
+        Err(Ok(Error::InsufficientRole))
+    );
+}
+
+// ── set_multipliers (ConfigAdmin+) ───────────────────────────────────────────
+
+#[test]
+fn test_set_multipliers_allowed_for_config_admin() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+    let config_admin = Address::generate(&env);
+    client.grant_role(&admin, &config_admin, &Role::ConfigAdmin);
+    assert!(client.try_set_multipliers(&config_admin, &20_000, &40_000, &70_000, &110_000).is_ok());
+}
+
+#[test]
+fn test_set_multipliers_rejected_for_pause_admin() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+    let pause_admin = Address::generate(&env);
+    client.grant_role(&admin, &pause_admin, &Role::PauseAdmin);
+    assert_eq!(
+        client.try_set_multipliers(&pause_admin, &20_000, &40_000, &70_000, &110_000),
+        Err(Ok(Error::InsufficientRole))
+    );
+}
+
+// ── set_treasury (SuperAdmin only) ────────────────────────────────────────────
+
+#[test]
+fn test_set_treasury_allowed_for_super_admin_only() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+    let new_treasury = Address::generate(&env);
+    assert!(client.try_set_treasury(&admin, &new_treasury).is_ok());
+}
+
+#[test]
+fn test_set_treasury_rejected_for_config_admin() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+    let config_admin = Address::generate(&env);
+    client.grant_role(&admin, &config_admin, &Role::ConfigAdmin);
+    let new_treasury = Address::generate(&env);
+    assert_eq!(
+        client.try_set_treasury(&config_admin, &new_treasury),
+        Err(Ok(Error::InsufficientRole))
+    );
+}
+
+#[test]
+fn test_set_treasury_rejected_for_pause_admin() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+    let pause_admin = Address::generate(&env);
+    client.grant_role(&admin, &pause_admin, &Role::PauseAdmin);
+    let new_treasury = Address::generate(&env);
+    assert_eq!(
+        client.try_set_treasury(&pause_admin, &new_treasury),
+        Err(Ok(Error::InsufficientRole))
+    );
+}
+
+// ── role upgrade / downgrade ──────────────────────────────────────────────────
+
+#[test]
+fn test_role_upgrade_grants_additional_permissions() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+    let operator = Address::generate(&env);
+
+    // Start as PauseAdmin — cannot set fee
+    client.grant_role(&admin, &operator, &Role::PauseAdmin);
+    assert_eq!(client.try_set_fee(&operator, &400), Err(Ok(Error::InsufficientRole)));
+
+    // Upgrade to ConfigAdmin — can now set fee
+    client.grant_role(&admin, &operator, &Role::ConfigAdmin);
+    assert!(client.try_set_fee(&operator, &400).is_ok());
+}
+
+#[test]
+fn test_revoked_role_loses_permissions() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+    let pause_admin = Address::generate(&env);
+    client.grant_role(&admin, &pause_admin, &Role::PauseAdmin);
+
+    // Can pause before revocation
+    assert!(client.try_set_paused(&pause_admin, &true).is_ok());
+    client.set_paused(&admin, &false); // reset
+
+    // Revoke and verify permission is gone
+    client.revoke_role(&admin, &pause_admin);
+    assert_eq!(
+        client.try_set_paused(&pause_admin, &true),
+        Err(Ok(Error::InsufficientRole))
+    );
+}


### PR DESCRIPTION
Here's what was implemented:                                                                       
                                                                                                     
  `Role` enum (orderable, PauseAdmin=0 < ConfigAdmin=1 < SuperAdmin=2) — stored per-address under    
  StorageKey::Role(Address).
  
  closes #458 