### PR TITLE
feat: implement emergency circuit breaker system

### DIFF
--- a/contract/src/circuit_breaker_tests.rs
+++ b/contract/src/circuit_breaker_tests.rs
@@ -1,0 +1,322 @@
+//! Tests for three new features:
+//!
+//! - #474: Reserve-threshold circuit breaker (`min_reserve_threshold`)
+//! - #475: Secret stored in `claim_winnings` HistoryEntry for `verify_past_game`
+//! - #476: Duplicate commitment rejection (`DuplicateCommitment`)
+
+use super::*;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::testutils::Ledger;
+
+// ── shared helpers ────────────────────────────────────────────────────────────
+
+fn setup(env: &Env) -> (soroban_sdk::Address, CoinflipContractClient) {
+    env.mock_all_auths();
+    let contract_id = env.register(CoinflipContract, ());
+    let client = CoinflipContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    let treasury = Address::generate(env);
+    let token = Address::generate(env);
+    client.initialize(&admin, &treasury, &token, &300, &1_000_000, &100_000_000);
+    (contract_id, client)
+}
+
+fn fund(env: &Env, contract_id: &soroban_sdk::Address, amount: i128) {
+    env.as_contract(contract_id, || {
+        let mut stats = CoinflipContract::load_stats(env);
+        stats.reserve_balance = amount;
+        CoinflipContract::save_stats(env, &stats);
+    });
+}
+
+fn get_admin(env: &Env, contract_id: &soroban_sdk::Address) -> Address {
+    env.as_contract(contract_id, || CoinflipContract::load_config(env).admin)
+}
+
+fn commitment_for(env: &Env, byte: u8) -> BytesN<32> {
+    env.crypto()
+        .sha256(&soroban_sdk::Bytes::from_slice(env, &[byte; 32]))
+        .into()
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// #474 — Reserve-threshold circuit breaker
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Circuit breaker is disabled by default (threshold == 0).
+#[test]
+fn test_circuit_breaker_disabled_by_default() {
+    let env = Env::default();
+    let (contract_id, _) = setup(&env);
+    let cfg: ContractConfig = env.as_contract(&contract_id, || {
+        CoinflipContract::load_config(&env)
+    });
+    assert_eq!(cfg.min_reserve_threshold, 0);
+}
+
+/// set_min_reserve_threshold persists the value.
+#[test]
+fn test_set_min_reserve_threshold_persists() {
+    let env = Env::default();
+    let (contract_id, client) = setup(&env);
+    let admin = get_admin(&env, &contract_id);
+    client.set_min_reserve_threshold(&admin, &50_000_000);
+    let cfg: ContractConfig = env.as_contract(&contract_id, || {
+        CoinflipContract::load_config(&env)
+    });
+    assert_eq!(cfg.min_reserve_threshold, 50_000_000);
+}
+
+/// Non-admin cannot set the threshold.
+#[test]
+fn test_set_min_reserve_threshold_rejects_non_admin() {
+    let env = Env::default();
+    let (_, client) = setup(&env);
+    let stranger = Address::generate(&env);
+    let result = client.try_set_min_reserve_threshold(&stranger, &50_000_000);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+/// start_game is rejected when reserves are exactly at the threshold.
+#[test]
+fn test_circuit_breaker_triggers_at_threshold() {
+    let env = Env::default();
+    let (contract_id, client) = setup(&env);
+    let admin = get_admin(&env, &contract_id);
+
+    let threshold = 100_000_000i128;
+    client.set_min_reserve_threshold(&admin, &threshold);
+    // Fund reserves to exactly the threshold value.
+    fund(&env, &contract_id, threshold);
+
+    let player = Address::generate(&env);
+    let result = client.try_start_game(&player, &Side::Heads, &1_000_000, &commitment_for(&env, 1));
+    assert_eq!(result, Err(Ok(Error::ContractPaused)));
+}
+
+/// start_game is rejected when reserves are below the threshold.
+#[test]
+fn test_circuit_breaker_triggers_below_threshold() {
+    let env = Env::default();
+    let (contract_id, client) = setup(&env);
+    let admin = get_admin(&env, &contract_id);
+
+    let threshold = 100_000_000i128;
+    client.set_min_reserve_threshold(&admin, &threshold);
+    fund(&env, &contract_id, threshold - 1);
+
+    let player = Address::generate(&env);
+    let result = client.try_start_game(&player, &Side::Heads, &1_000_000, &commitment_for(&env, 1));
+    assert_eq!(result, Err(Ok(Error::ContractPaused)));
+}
+
+/// start_game succeeds when reserves are strictly above the threshold.
+#[test]
+fn test_circuit_breaker_allows_game_above_threshold() {
+    let env = Env::default();
+    let (contract_id, client) = setup(&env);
+    let admin = get_admin(&env, &contract_id);
+
+    let threshold = 50_000_000i128;
+    client.set_min_reserve_threshold(&admin, &threshold);
+    // Fund well above threshold and above worst-case payout for 1_000_000 wager.
+    fund(&env, &contract_id, threshold + 10_000_000);
+
+    let player = Address::generate(&env);
+    let result = client.try_start_game(&player, &Side::Heads, &1_000_000, &commitment_for(&env, 1));
+    assert!(result.is_ok());
+}
+
+/// Setting threshold to 0 disables the circuit breaker.
+#[test]
+fn test_circuit_breaker_disabled_when_threshold_zero() {
+    let env = Env::default();
+    let (contract_id, client) = setup(&env);
+    let admin = get_admin(&env, &contract_id);
+
+    // Enable then disable.
+    client.set_min_reserve_threshold(&admin, &100_000_000);
+    client.set_min_reserve_threshold(&admin, &0);
+    fund(&env, &contract_id, 1_000_000_000);
+
+    let player = Address::generate(&env);
+    let result = client.try_start_game(&player, &Side::Heads, &1_000_000, &commitment_for(&env, 1));
+    assert!(result.is_ok());
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// #475 — Secret stored in claim_winnings HistoryEntry
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// verify_past_game returns true for a game settled via claim_winnings
+/// when the correct secret is supplied.
+#[test]
+fn test_claim_winnings_stores_secret_for_verification() {
+    let env = Env::default();
+    let (contract_id, client) = setup(&env);
+    fund(&env, &contract_id, 1_000_000_000);
+
+    let player = Address::generate(&env);
+    let secret = soroban_sdk::Bytes::from_slice(&env, &[1u8; 32]);
+    let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
+
+    client.start_game(&player, &Side::Heads, &10_000_000, &commitment);
+    // Force a win by injecting Revealed state with streak=1.
+    env.as_contract(&contract_id, || {
+        let mut game = CoinflipContract::load_player_game(&env, &player).unwrap();
+        game.streak = 1;
+        game.phase = GamePhase::Revealed;
+        CoinflipContract::save_player_game(&env, &player, &game);
+    });
+
+    client.claim_winnings(&player, &secret);
+
+    // verify_past_game must succeed (returns true) because the secret is stored.
+    let verified = client.verify_past_game(&player, &0);
+    assert_eq!(verified, Ok(true));
+}
+
+/// verify_past_game returns false when an empty secret is stored (old behaviour
+/// for cash_out path — regression guard).
+#[test]
+fn test_cash_out_empty_secret_verify_returns_false() {
+    let env = Env::default();
+    let (contract_id, client) = setup(&env);
+    fund(&env, &contract_id, 1_000_000_000);
+
+    let player = Address::generate(&env);
+    let secret = soroban_sdk::Bytes::from_slice(&env, &[1u8; 32]);
+    let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
+
+    client.start_game(&player, &Side::Heads, &10_000_000, &commitment);
+    env.as_contract(&contract_id, || {
+        let mut game = CoinflipContract::load_player_game(&env, &player).unwrap();
+        game.streak = 1;
+        game.phase = GamePhase::Revealed;
+        CoinflipContract::save_player_game(&env, &player, &game);
+    });
+
+    client.cash_out(&player);
+
+    // cash_out stores empty secret → verify_past_game returns false.
+    let verified = client.verify_past_game(&player, &0);
+    assert_eq!(verified, Ok(false));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// #476 — Duplicate commitment rejection
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// A commitment used in a previous game is rejected in start_game.
+#[test]
+fn test_duplicate_commitment_rejected_in_start_game() {
+    let env = Env::default();
+    let (contract_id, client) = setup(&env);
+    fund(&env, &contract_id, 1_000_000_000);
+
+    let player1 = Address::generate(&env);
+    let player2 = Address::generate(&env);
+    let commitment = commitment_for(&env, 42);
+
+    // First use succeeds.
+    client.start_game(&player1, &Side::Heads, &1_000_000, &commitment);
+
+    // Same commitment for a different player must be rejected.
+    let result = client.try_start_game(&player2, &Side::Heads, &1_000_000, &commitment);
+    assert_eq!(result, Err(Ok(Error::DuplicateCommitment)));
+}
+
+/// A fresh commitment is always accepted.
+#[test]
+fn test_fresh_commitment_accepted() {
+    let env = Env::default();
+    let (contract_id, client) = setup(&env);
+    fund(&env, &contract_id, 1_000_000_000);
+
+    let player1 = Address::generate(&env);
+    let player2 = Address::generate(&env);
+
+    client.start_game(&player1, &Side::Heads, &1_000_000, &commitment_for(&env, 1));
+    let result = client.try_start_game(&player2, &Side::Heads, &1_000_000, &commitment_for(&env, 2));
+    assert!(result.is_ok());
+}
+
+/// A commitment used in start_game is rejected in continue_streak.
+#[test]
+fn test_duplicate_commitment_rejected_in_continue_streak() {
+    let env = Env::default();
+    let (contract_id, client) = setup(&env);
+    fund(&env, &contract_id, 1_000_000_000);
+
+    let player = Address::generate(&env);
+    let first_commitment = commitment_for(&env, 10);
+
+    client.start_game(&player, &Side::Heads, &1_000_000, &first_commitment);
+
+    // Inject Revealed/win state so continue_streak is eligible.
+    env.as_contract(&contract_id, || {
+        let mut game = CoinflipContract::load_player_game(&env, &player).unwrap();
+        game.streak = 1;
+        game.phase = GamePhase::Revealed;
+        CoinflipContract::save_player_game(&env, &player, &game);
+    });
+
+    // Reusing the same commitment must be rejected.
+    let result = client.try_continue_streak(&player, &first_commitment);
+    assert_eq!(result, Err(Ok(Error::DuplicateCommitment)));
+}
+
+/// A fresh commitment in continue_streak is accepted.
+#[test]
+fn test_fresh_commitment_accepted_in_continue_streak() {
+    let env = Env::default();
+    let (contract_id, client) = setup(&env);
+    fund(&env, &contract_id, 1_000_000_000);
+
+    let player = Address::generate(&env);
+    client.start_game(&player, &Side::Heads, &1_000_000, &commitment_for(&env, 10));
+
+    env.as_contract(&contract_id, || {
+        let mut game = CoinflipContract::load_player_game(&env, &player).unwrap();
+        game.streak = 1;
+        game.phase = GamePhase::Revealed;
+        CoinflipContract::save_player_game(&env, &player, &game);
+    });
+
+    env.ledger().with_mut(|l| l.sequence_number += 1);
+    let result = client.try_continue_streak(&player, &commitment_for(&env, 99));
+    assert!(result.is_ok());
+}
+
+/// No state mutation when DuplicateCommitment fires.
+#[test]
+fn test_duplicate_commitment_no_state_mutation() {
+    let env = Env::default();
+    let (contract_id, client) = setup(&env);
+    fund(&env, &contract_id, 1_000_000_000);
+
+    let player1 = Address::generate(&env);
+    let player2 = Address::generate(&env);
+    let commitment = commitment_for(&env, 77);
+
+    client.start_game(&player1, &Side::Heads, &1_000_000, &commitment);
+
+    let stats_before: ContractStats = env.as_contract(&contract_id, || {
+        CoinflipContract::load_stats(&env)
+    });
+
+    let _ = client.try_start_game(&player2, &Side::Heads, &1_000_000, &commitment);
+
+    let stats_after: ContractStats = env.as_contract(&contract_id, || {
+        CoinflipContract::load_stats(&env)
+    });
+
+    assert_eq!(stats_before.total_games, stats_after.total_games);
+    assert_eq!(stats_before.total_volume, stats_after.total_volume);
+
+    // player2 must have no game stored.
+    let game: Option<GameState> = env.as_contract(&contract_id, || {
+        CoinflipContract::load_player_game(&env, &player2).unwrap()
+    });
+    assert!(game.is_none());
+}

--- a/contract/src/error_tests.rs
+++ b/contract/src/error_tests.rs
@@ -1,7 +1,7 @@
 /// Comprehensive error code stability validation tests for the Tossd contract.
 ///
 /// # Coverage
-/// - Test all 17 error variants are reachable
+/// - Test all 18 error variants are reachable
 /// - Validate error code numeric stability
 /// - Ensure error messages are descriptive
 /// - Test error propagation through call stack
@@ -39,12 +39,13 @@ fn error_codes_match_constants() {
     assert_eq!(error_codes::TRANSFER_FAILED, 40);
     assert_eq!(error_codes::ADMIN_TREASURY_CONFLICT, 50);
     assert_eq!(error_codes::ALREADY_INITIALIZED, 51);
+    assert_eq!(error_codes::DUPLICATE_COMMITMENT, 52);
 }
 
 /// Verify error code variant count matches documented value.
 #[test]
 fn error_codes_variant_count_correct() {
-    assert_eq!(error_codes::VARIANT_COUNT, 17);
+    assert_eq!(error_codes::VARIANT_COUNT, 18);
 }
 
 // ── Error reachability tests ────────────────────────────────────────────────
@@ -453,4 +454,9 @@ fn error_code_reference_documentation() {
     //   - Contract has already been initialized
     //   - Returned by: initialize
     //   - Resolution: Contract can only be initialized once
+    //
+    // Code 52: DuplicateCommitment
+    //   - Commitment has already been used in a previous game
+    //   - Returned by: start_game, continue_streak
+    //   - Resolution: Generate a fresh secret and commitment for each game
 }

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -87,9 +87,10 @@ pub mod error_codes {
     // Initialization errors (50–51)
     pub const ADMIN_TREASURY_CONFLICT: u32 = 50;
     pub const ALREADY_INITIALIZED: u32 = 51;
+    pub const DUPLICATE_COMMITMENT: u32 = 52;
 
     /// Total number of defined error variants.
-    pub const VARIANT_COUNT: usize = 17;
+    pub const VARIANT_COUNT: usize = 18;
 }
 
 /// Error codes for the coinflip contract.
@@ -206,6 +207,11 @@ pub enum Error {
     /// Returned by: `initialize`.
     /// Code: 51 — see [`error_codes::ALREADY_INITIALIZED`]
     AlreadyInitialized = 51,
+
+    /// Commitment has already been used in a previous game; reuse is rejected.
+    /// Returned by: `start_game`, `continue_streak`.
+    /// Code: 52 — prevents replay attacks.
+    DuplicateCommitment = 52,
 }
 
 /// The player's chosen side for a coinflip.
@@ -301,6 +307,10 @@ pub struct ContractConfig {
     pub max_wager: i128,
     /// Emergency pause flag; when `true`, `start_game` is rejected.
     pub paused: bool,
+    /// Circuit-breaker threshold in stroops. When `reserve_balance` drops at or
+    /// below this value, `start_game` is auto-paused with [`Error::ContractPaused`].
+    /// Set to 0 to disable the circuit breaker.
+    pub min_reserve_threshold: i128,
 }
 
 /// Aggregate statistics stored in persistent storage under [`StorageKey::Stats`].
@@ -379,6 +389,8 @@ pub enum StorageKey {
     PlayerGame(Address),
     /// Per-player game history ring-buffer ([`Vec<HistoryEntry>`]), keyed by player address.
     PlayerHistory(Address),
+    /// Set of used commitment hashes to prevent replay attacks.
+    UsedCommitments,
 }
 
 /// Multiplier values in basis points (1 bps = 0.0001x).
@@ -615,6 +627,7 @@ impl CoinflipContract {
             min_wager,
             max_wager,
             paused: false,
+            min_reserve_threshold: 0,
         };
         
         let stats = ContractStats {
@@ -814,6 +827,16 @@ impl CoinflipContract {
             return Err(Error::InsufficientReserves);
         }
 
+        // Guard 6 (circuit breaker): auto-pause when reserves drop at or below threshold.
+        if config.min_reserve_threshold > 0 && stats.reserve_balance <= config.min_reserve_threshold {
+            return Err(Error::ContractPaused);
+        }
+
+        // Guard 7: reject reused commitments to prevent replay attacks.
+        if Self::is_commitment_used(&env, &commitment) {
+            return Err(Error::DuplicateCommitment);
+        }
+
         // Generate contract-side randomness contribution from ledger sequence
         let seq_bytes = env.ledger().sequence().to_be_bytes();
         let contract_random: BytesN<32> = env.crypto().sha256(
@@ -832,6 +855,7 @@ impl CoinflipContract {
         };
 
         Self::save_player_game(&env, &player, &game);
+        Self::mark_commitment_used(&env, &game.commitment);
 
         // Update global statistics to reflect a new active game creation.
         let mut stats = stats;
@@ -983,6 +1007,7 @@ impl CoinflipContract {
     pub fn claim_winnings(
         env: Env,
         player: Address,
+        secret: Bytes,
     ) -> Result<(), Error> {
         player.require_auth();
 
@@ -1024,6 +1049,20 @@ impl CoinflipContract {
             .ok_or(Error::InsufficientReserves)?;
         stats.total_fees = stats.total_fees.checked_add(fee_amount).unwrap_or(stats.total_fees);
         Self::save_stats(&env, &stats);
+
+        // Record history with the provided secret so verify_past_game works.
+        Self::save_history_entry(&env, &player, HistoryEntry {
+            wager: game.wager,
+            side: game.side,
+            outcome: game.side, // won, so outcome == side
+            won: true,
+            streak: game.streak,
+            commitment: game.commitment.clone(),
+            secret,
+            contract_random: game.contract_random.clone(),
+            payout: net_payout,
+            ledger: game.start_ledger,
+        });
 
         // Mark game completed before transfers for the same reason.
         game.phase = GamePhase::Completed;
@@ -1213,6 +1252,11 @@ impl CoinflipContract {
             return Err(Error::InvalidCommitment);
         }
 
+        // Guard 4b: reject reused commitments to prevent replay attacks.
+        if Self::is_commitment_used(&env, &new_commitment) {
+            return Err(Error::DuplicateCommitment);
+        }
+
         // Guard 5: reserves must cover the next streak's worst-case payout.
         // Config is not needed here — all required data (wager, streak) is in GameState.
         let stats = Self::load_stats(&env);
@@ -1235,10 +1279,11 @@ impl CoinflipContract {
 
         // Reset to Committed phase; preserve streak and wager
         game.phase = GamePhase::Committed;
-        game.commitment = new_commitment;
+        game.commitment = new_commitment.clone();
         game.contract_random = contract_random.into();
 
         Self::save_player_game(&env, &player, &game);
+        Self::mark_commitment_used(&env, &new_commitment);
 
         Ok(())
     }
@@ -1391,6 +1436,49 @@ impl CoinflipContract {
         Self::save_config(&env, &config);
 
         Ok(())
+    }
+
+    /// Update the circuit-breaker reserve threshold.
+    ///
+    /// When `reserve_balance <= min_reserve_threshold`, `start_game` is automatically
+    /// rejected with [`Error::ContractPaused`]. Set to `0` to disable.
+    ///
+    /// # Errors
+    /// - [`Error::Unauthorized`] – caller is not the configured admin
+    pub fn set_min_reserve_threshold(env: Env, admin: Address, threshold: i128) -> Result<(), Error> {
+        admin.require_auth();
+        let mut config = Self::load_config(&env);
+        if admin != config.admin {
+            return Err(Error::Unauthorized);
+        }
+        config.min_reserve_threshold = threshold;
+        Self::save_config(&env, &config);
+        Ok(())
+    }
+
+    // ── Commitment nonce tracking helpers ───────────────────────────────────
+
+    /// Returns `true` if `commitment` has already been used in a previous game.
+    fn is_commitment_used(env: &Env, commitment: &BytesN<32>) -> bool {
+        let key = StorageKey::UsedCommitments;
+        let used: soroban_sdk::Vec<BytesN<32>> = env
+            .storage()
+            .instance()
+            .get(&key)
+            .unwrap_or_else(|| soroban_sdk::Vec::new(env));
+        used.contains(commitment)
+    }
+
+    /// Record `commitment` as used so future attempts are rejected.
+    fn mark_commitment_used(env: &Env, commitment: &BytesN<32>) {
+        let key = StorageKey::UsedCommitments;
+        let mut used: soroban_sdk::Vec<BytesN<32>> = env
+            .storage()
+            .instance()
+            .get(&key)
+            .unwrap_or_else(|| soroban_sdk::Vec::new(env));
+        used.push_back(commitment.clone());
+        env.storage().instance().set(&key, &used);
     }
 
     /// Reclaim a wager from a game that has exceeded the reveal timeout.
@@ -1637,6 +1725,9 @@ mod statistics_tests;
 mod admin_security_tests;
 
 #[cfg(test)]
+mod circuit_breaker_tests;
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use soroban_sdk::testutils::Address as _;
@@ -1772,6 +1863,7 @@ mod tests {
         assert_eq!(Error::TransferFailed as u32, 40);
         assert_eq!(Error::AdminTreasuryConflict as u32, 50);
         assert_eq!(Error::AlreadyInitialized as u32, 51);
+        assert_eq!(Error::DuplicateCommitment as u32, 52);
     }
 
     #[test]
@@ -2229,7 +2321,7 @@ mod tests {
         // Inject a Revealed game with streak == 0 (loss state).
         inject_game(&env, &contract_id, &player, GamePhase::Revealed, 0, 10_000_000);
 
-        let result = client.try_claim_winnings(&player);
+        let result = client.try_claim_winnings(&player, &Bytes::new(&env));
         assert_eq!(result, Err(Ok(Error::NoWinningsToClaimOrContinue)));
 
         // State must be unchanged — no partial mutation.
@@ -5139,14 +5231,15 @@ mod property_tests {
             prop_assert_eq!(Error::TransferFailed as u32, error_codes::TRANSFER_FAILED);
             prop_assert_eq!(Error::AdminTreasuryConflict as u32, error_codes::ADMIN_TREASURY_CONFLICT);
             prop_assert_eq!(Error::AlreadyInitialized as u32, error_codes::ALREADY_INITIALIZED);
+            prop_assert_eq!(Error::DuplicateCommitment as u32, error_codes::DUPLICATE_COMMITMENT);
         }
 
         /// VARIANT_COUNT must exactly match the number of Error enum variants.
         #[test]
         fn prop_variant_count_is_accurate(_dummy in 0u32..100u32) {
-            // All 17 variants enumerated — if a new variant is added without
+            // All 18 variants enumerated — if a new variant is added without
             // updating VARIANT_COUNT, this list will need to grow.
-            let all_codes: [u32; 17] = [
+            let all_codes: [u32; 18] = [
                 error_codes::WAGER_BELOW_MINIMUM,
                 error_codes::WAGER_ABOVE_MAXIMUM,
                 error_codes::ACTIVE_GAME_EXISTS,
@@ -5164,6 +5257,7 @@ mod property_tests {
                 error_codes::TRANSFER_FAILED,
                 error_codes::ADMIN_TREASURY_CONFLICT,
                 error_codes::ALREADY_INITIALIZED,
+                error_codes::DUPLICATE_COMMITMENT,
             ];
             prop_assert_eq!(all_codes.len(), error_codes::VARIANT_COUNT);
         }
@@ -8639,8 +8733,8 @@ mod security_penetration_tests {
         env.as_contract(&contract_id, || {
             CoinflipContract::save_player_game(&env, &player, &game);
         });
-        let _ = client.try_claim_winnings(&player);
-        let second = client.try_claim_winnings(&player);
+        let _ = client.try_claim_winnings(&player, &Bytes::new(&env));
+        let second = client.try_claim_winnings(&player, &Bytes::new(&env));
         assert!(
             second == Err(Ok(Error::InvalidPhase)) || second == Err(Ok(Error::NoActiveGame)),
             "second claim must be rejected: {:?}", second

--- a/contract/src/phase_transition_tests.rs
+++ b/contract/src/phase_transition_tests.rs
@@ -256,7 +256,7 @@ fn claim_winnings_from_committed_is_invalid_phase() {
     fund(&env, &contract_id, 1_000_000_000);
     let player = Address::generate(&env);
     inject(&env, &contract_id, &player, GamePhase::Committed, 1);
-    assert_eq!(client.try_claim_winnings(&player), Err(Ok(Error::InvalidPhase)));
+    assert_eq!(client.try_claim_winnings(&player, &soroban_sdk::Bytes::new(&env)), Err(Ok(Error::InvalidPhase)));
 }
 
 /// continue_streak from Committed → InvalidPhase.

--- a/contract/src/snapshot_tests.rs
+++ b/contract/src/snapshot_tests.rs
@@ -254,7 +254,8 @@ fn error_enum_stable_codes() {
     // Verify stable u32 discriminants (protocol contract)
     assert_eq!(Error::WagerBelowMinimum as u32, 1);
     assert_eq!(Error::AlreadyInitialized as u32, 51);
-    // All 17 codes covered in lib.rs error_codes::VARIANT_COUNT
+    assert_eq!(Error::DuplicateCommitment as u32, 52);
+    // All 18 codes covered in lib.rs error_codes::VARIANT_COUNT
 }
 
 // ── Backward Compatibility Probes ────────────────────────────────────────────
@@ -401,5 +402,5 @@ fn upgrade_simulation_stats_compatibility() {
 fn storage_versioning_documented() {
     // This test serves as documentation of the storage layout versioning strategy
     // and ensures the strategy is maintained across upgrades
-    assert_eq!(error_codes::VARIANT_COUNT, 17);
+    assert_eq!(error_codes::VARIANT_COUNT, 18);
 }


### PR DESCRIPTION
closes #474 
closes #475 
closes #476 



feat: implement emergency circuit breaker system                                              
                                                                                                
  #474 — Reserve-threshold circuit breaker (auto-pause)                                         
                                                                                                
  Problem: The contract had a manual pause (set_paused) but no automatic protection against     
  reserve depletion. An admin would have to manually notice and react before the contract       
  accepted bets it couldn't honour.                                                             
                                                                                                
  Solution: Added a configurable min_reserve_threshold to ContractConfig. When set, start_game  
  automatically rejects new games with ContractPaused if reserve_balance <= threshold. Setting  
  it to 0 (the default) disables the circuit breaker entirely, preserving backward              
  compatibility.                                                                                
                                                                                                
  Changes:                                                                                      
  - ContractConfig.min_reserve_threshold: i128 — new field, defaults to 0                       
  - start_game guard 6: auto-pause check after the solvency check                               
  - set_min_reserve_threshold(admin, threshold) — new admin function to configure the threshold 
                                                                                                
  ──────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                
  #475 — Full cryptographic verifiability for `claim_winnings`                                  
                                                                                                
  Problem: claim_winnings settled games with a token transfer but stored an empty Bytes as the  
  secret in HistoryEntry. This meant verify_past_game always returned false for games settled   
  via this path — the on-chain proof was incomplete.                                            
                                                                                                
  Solution: claim_winnings now accepts the player's secret: Bytes as a parameter and stores it  
  in HistoryEntry. This makes the full commit-reveal proof (SHA-256(secret) == commitment and   
  SHA-256(secret || contract_random) == outcome) independently verifiable for every settlement  
  path.                                                                                         
                                                                                                
  Changes:                                                                                      
                                                                                                
  - claim_winnings(env, player, secret) — added secret parameter                                
  - HistoryEntry now populated with the real secret instead of Bytes::new()                     
  - All existing claim_winnings call sites in tests updated to pass Bytes::new() (error-path    
  tests where the secret is irrelevant)                                                         
                                                                                                
  ──────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                
  #476 — Commitment replay attack prevention                                                    
                                                                                                
  Problem: Nothing prevented a player from reusing a commitment (and its corresponding secret)  
  from a previous game. A player who observed a winning (secret, contract_random) pair could    
  attempt to replay it in a future game.                                                        
                                                                                                
  Solution: Used commitments are tracked in a Vec<BytesN<32>> stored under                      
  StorageKey::UsedCommitments in instance storage. Both start_game and continue_streak check    
  this set before accepting a commitment, rejecting reuse with the new                          
  Error::DuplicateCommitment (code 52).                                                         
                                                                                                
  Changes:                                                                                      
                                                                                                
  - StorageKey::UsedCommitments — new instance storage key                                      
  - Error::DuplicateCommitment = 52 — new stable error code                                     
  - error_codes::DUPLICATE_COMMITMENT: u32 = 52 — new constant                                  
  - is_commitment_used(env, commitment) -> bool — internal helper                               
  - mark_commitment_used(env, commitment) — internal helper                                     
  - start_game guard 7: duplicate commitment check                                              
  - continue_streak guard 4b: duplicate commitment check                                        
  - VARIANT_COUNT updated from 17 → 18 across all test files                                    
                                                                                                
  ──────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                
  Tests                                                                                         
                                                                                                
  New file contract/src/circuit_breaker_tests.rs with 11 tests:                                 
                                                                                                
  ┌────────────────────────────────────────────────────┬───────────────────────────┐            
  │ Test                                               │ Covers                    │            
  ├────────────────────────────────────────────────────┼───────────────────────────┤            
  │ `test_circuit_breaker_disabled_by_default`          │ threshold defaults to 0   │           
  │ `test_set_min_reserve_threshold_persists`            │ admin can set threshold       │      
  │ `test_set_min_reserve_threshold_rejects_non_admin`   │ unauthorized rejected              │ 
  │ `test_circuit_breaker_triggers_at_threshold`         │ blocks at exact threshold          │ 
  │ `test_circuit_breaker_triggers_below_threshold`      │ blocks below threshold             │ 
  │ `test_set_min_reserve_threshold_persists`               │ admin can set threshold           
              │                                                                                 
  │ `test_set_min_reserve_threshold_rejects_non_admin`      │ unauthorized rejected             
                │                                                                               
  │ `test_circuit_breaker_triggers_at_threshold`            │ blocks at exact threshold         
            │                                                                                   
  │ `test_circuit_breaker_triggers_below_threshold`         │ blocks below threshold            
               │                                                                                
  │ `test_circuit_breaker_allows_game_above_threshold`      │ allows above threshold            
               │                                                                                
  │ `test_circuit_breaker_disabled_when_threshold_zero`     │ zero disables it                  
                     │                                                                          
  │ `test_claim_winnings_stores_secret_for_verification`    │ verify_past_game returns true     
        │                                                                                       
  │ `test_cash_out_empty_secret_verify_returns_false`       │ regression guard for cash_out path
   │                                                                                            
  │ `test_duplicate_commitment_rejected_in_start_game`      │ replay blocked in start_game      
         │                                                                                      
  │ `test_fresh_commitment_accepted`                        │ fresh commitments still work      
         │                                                                                      
  │ `test_duplicate_commitment_rejected_in_continue_streak` │ replay blocked in continue_streak 
    │                                                                                           
  │ `test_fresh_commitment_accepted_in_continue_streak`     │ fresh commitments work in continue
   │                                                                                            
  │ `test_duplicate_commitment_no_state_mutation`           │ no partial state on rejection     
        │                                                                                       
  └─────────────────────────────────────────────────────────┴───────────────────────────────────
  ─┘                                                                                            
                                                                                                