### PR TITLE
feat: add entropy pool for randomness enhancement

### DIFF
--- a/contract/src/entropy_tests.rs
+++ b/contract/src/entropy_tests.rs
@@ -1,0 +1,308 @@
+//! Tests for the entropy pool: accumulation, mixing, and quality metrics.
+
+use super::*;
+use soroban_sdk::testutils::{Address as _, Ledger};
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn setup(env: &Env) -> (Address, CoinflipContractClient) {
+    env.mock_all_auths();
+    let contract_id = env.register(CoinflipContract, ());
+    let client = CoinflipContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    let treasury = Address::generate(env);
+    let token = Address::generate(env);
+    client.initialize(&admin, &treasury, &token, &300, &1_000_000, &100_000_000);
+    (contract_id, client)
+}
+
+fn fund(env: &Env, contract_id: &Address, amount: i128) {
+    env.as_contract(contract_id, || {
+        let mut stats = CoinflipContract::load_stats(env);
+        stats.reserve_balance = amount;
+        CoinflipContract::save_stats(env, &stats);
+    });
+}
+
+fn load_entropy(env: &Env, contract_id: &Address) -> EntropyPool {
+    env.as_contract(contract_id, || CoinflipContract::load_entropy_pool(env))
+}
+
+fn load_stats(env: &Env, contract_id: &Address) -> ContractStats {
+    env.as_contract(contract_id, || CoinflipContract::load_stats(env))
+}
+
+fn commitment(env: &Env, seed: u8) -> BytesN<32> {
+    env.crypto()
+        .sha256(&soroban_sdk::Bytes::from_slice(env, &[seed; 32]))
+        .into()
+}
+
+// ── Accumulation tests ────────────────────────────────────────────────────────
+
+/// initialize seeds the entropy pool with pool_size == 1.
+#[test]
+fn test_entropy_pool_initialized_on_contract_init() {
+    let env = Env::default();
+    let (contract_id, _client) = setup(&env);
+
+    let entropy = load_entropy(&env, &contract_id);
+    assert_eq!(entropy.pool_size, 1, "pool_size must be 1 after initialize");
+    assert_eq!(entropy.mix_count, 0, "mix_count must be 0 after initialize");
+    // Pool must not be all-zero (seeded from ledger sequence hash).
+    assert_ne!(entropy.pool, BytesN::from_array(&env, &[0u8; 32]));
+}
+
+/// start_game accumulates entropy: pool_size increments by 1.
+#[test]
+fn test_start_game_accumulates_entropy() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract_id, client) = setup(&env);
+    fund(&env, &contract_id, 1_000_000_000);
+
+    let before = load_entropy(&env, &contract_id);
+    let player = Address::generate(&env);
+    client.start_game(&player, &Side::Heads, &10_000_000, &commitment(&env, 1));
+    let after = load_entropy(&env, &contract_id);
+
+    assert_eq!(after.pool_size, before.pool_size + 1);
+}
+
+/// start_game mixes entropy: mix_count increments by 1.
+#[test]
+fn test_start_game_mixes_entropy() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract_id, client) = setup(&env);
+    fund(&env, &contract_id, 1_000_000_000);
+
+    let before = load_entropy(&env, &contract_id);
+    let player = Address::generate(&env);
+    client.start_game(&player, &Side::Heads, &10_000_000, &commitment(&env, 1));
+    let after = load_entropy(&env, &contract_id);
+
+    assert_eq!(after.mix_count, before.mix_count + 1);
+}
+
+/// continue_streak also accumulates and mixes entropy.
+#[test]
+fn test_continue_streak_accumulates_and_mixes_entropy() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract_id, client) = setup(&env);
+    fund(&env, &contract_id, 1_000_000_000);
+
+    let player = Address::generate(&env);
+    // Start and win a game (seed 1 → Heads win).
+    client.start_game(&player, &Side::Heads, &10_000_000, &commitment(&env, 1));
+    let secret = soroban_sdk::Bytes::from_slice(&env, &[1u8; 32]);
+    assert_eq!(client.reveal(&player, &secret), true);
+
+    let before = load_entropy(&env, &contract_id);
+    env.ledger().with_mut(|l| l.sequence_number += 1);
+    client.continue_streak(&player, &commitment(&env, 2));
+    let after = load_entropy(&env, &contract_id);
+
+    assert_eq!(after.pool_size, before.pool_size + 1, "pool_size must increment on continue");
+    assert_eq!(after.mix_count, before.mix_count + 1, "mix_count must increment on continue");
+}
+
+/// Pool value changes after each accumulation (XOR with distinct contributions).
+#[test]
+fn test_entropy_pool_value_changes_across_games() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract_id, client) = setup(&env);
+    fund(&env, &contract_id, 1_000_000_000_000);
+
+    let pool_after_init = load_entropy(&env, &contract_id).pool;
+
+    // Advance ledger so each game gets a distinct contribution.
+    env.ledger().with_mut(|l| l.sequence_number += 1);
+    let p1 = Address::generate(&env);
+    client.start_game(&p1, &Side::Heads, &10_000_000, &commitment(&env, 1));
+    let pool_after_game1 = load_entropy(&env, &contract_id).pool;
+
+    env.ledger().with_mut(|l| l.sequence_number += 1);
+    let p2 = Address::generate(&env);
+    client.start_game(&p2, &Side::Heads, &10_000_000, &commitment(&env, 2));
+    let pool_after_game2 = load_entropy(&env, &contract_id).pool;
+
+    assert_ne!(pool_after_init, pool_after_game1, "pool must change after first game");
+    assert_ne!(pool_after_game1, pool_after_game2, "pool must change after second game");
+}
+
+// ── Mixing tests ──────────────────────────────────────────────────────────────
+
+/// contract_random stored in GameState differs from the raw SHA-256(sequence)
+/// because the entropy pool is XOR-mixed in.
+#[test]
+fn test_contract_random_is_entropy_mixed() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract_id, client) = setup(&env);
+    fund(&env, &contract_id, 1_000_000_000);
+
+    let player = Address::generate(&env);
+    client.start_game(&player, &Side::Heads, &10_000_000, &commitment(&env, 1));
+
+    let game: GameState = env.as_contract(&contract_id, || {
+        CoinflipContract::load_player_game(&env, &player).unwrap()
+    });
+
+    // Raw SHA-256 of the ledger sequence (what the old code would have stored).
+    let seq_bytes = env.ledger().sequence().to_be_bytes();
+    let raw_random: BytesN<32> = env
+        .crypto()
+        .sha256(&soroban_sdk::Bytes::from_slice(&env, &seq_bytes))
+        .into();
+
+    // The stored contract_random must differ from the raw value because the
+    // entropy pool was XOR-mixed in.
+    assert_ne!(
+        game.contract_random, raw_random,
+        "contract_random must be entropy-mixed, not raw SHA-256(sequence)"
+    );
+}
+
+/// Two games at the same ledger sequence but different pool states produce
+/// different contract_random values.
+#[test]
+fn test_same_sequence_different_pool_yields_different_random() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    // Contract A: one game started.
+    let cid_a = env.register(CoinflipContract, ());
+    let client_a = CoinflipContractClient::new(&env, &cid_a);
+    let admin_a = Address::generate(&env);
+    let treasury_a = Address::generate(&env);
+    let token_a = Address::generate(&env);
+    client_a.initialize(&admin_a, &treasury_a, &token_a, &300, &1_000_000, &100_000_000);
+    fund(&env, &cid_a, 1_000_000_000);
+
+    // Contract B: two games started before the game we care about.
+    let cid_b = env.register(CoinflipContract, ());
+    let client_b = CoinflipContractClient::new(&env, &cid_b);
+    let admin_b = Address::generate(&env);
+    let treasury_b = Address::generate(&env);
+    let token_b = Address::generate(&env);
+    client_b.initialize(&admin_b, &treasury_b, &token_b, &300, &1_000_000, &100_000_000);
+    fund(&env, &cid_b, 1_000_000_000);
+
+    // Warm up contract B's pool with an extra game.
+    let warmup = Address::generate(&env);
+    client_b.start_game(&warmup, &Side::Heads, &1_000_000, &commitment(&env, 99));
+
+    // Now both contracts start a game at the same ledger sequence.
+    let player_a = Address::generate(&env);
+    let player_b = Address::generate(&env);
+    client_a.start_game(&player_a, &Side::Heads, &10_000_000, &commitment(&env, 1));
+    client_b.start_game(&player_b, &Side::Heads, &10_000_000, &commitment(&env, 1));
+
+    let game_a: GameState = env.as_contract(&cid_a, || {
+        CoinflipContract::load_player_game(&env, &player_a).unwrap()
+    });
+    let game_b: GameState = env.as_contract(&cid_b, || {
+        CoinflipContract::load_player_game(&env, &player_b).unwrap()
+    });
+
+    assert_ne!(
+        game_a.contract_random, game_b.contract_random,
+        "different pool states must produce different contract_random values"
+    );
+}
+
+// ── Quality metric tests ──────────────────────────────────────────────────────
+
+/// stats.pool_size reflects the total entropy contributions.
+#[test]
+fn test_stats_pool_size_tracks_accumulations() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract_id, client) = setup(&env);
+    fund(&env, &contract_id, 1_000_000_000_000);
+
+    // After initialize: pool_size == 1 (seeded in initialize).
+    let stats = load_stats(&env, &contract_id);
+    assert_eq!(stats.pool_size, 1);
+
+    // Each start_game adds 1.
+    for i in 0..3u32 {
+        env.ledger().with_mut(|l| l.sequence_number += 1);
+        let player = Address::generate(&env);
+        client.start_game(&player, &Side::Heads, &10_000_000, &commitment(&env, i as u8 + 1));
+    }
+
+    let stats = load_stats(&env, &contract_id);
+    assert_eq!(stats.pool_size, 4, "pool_size must be 1 (init) + 3 (games)");
+}
+
+/// stats.mix_count reflects the total mix operations.
+#[test]
+fn test_stats_mix_count_tracks_mixes() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract_id, client) = setup(&env);
+    fund(&env, &contract_id, 1_000_000_000_000);
+
+    // After initialize: mix_count == 0.
+    let stats = load_stats(&env, &contract_id);
+    assert_eq!(stats.mix_count, 0);
+
+    // Each start_game mixes once.
+    for i in 0..3u32 {
+        env.ledger().with_mut(|l| l.sequence_number += 1);
+        let player = Address::generate(&env);
+        client.start_game(&player, &Side::Heads, &10_000_000, &commitment(&env, i as u8 + 1));
+    }
+
+    let stats = load_stats(&env, &contract_id);
+    assert_eq!(stats.mix_count, 3, "mix_count must equal number of games started");
+}
+
+/// pool_size and mix_count are monotonically non-decreasing.
+#[test]
+fn test_quality_metrics_are_monotonically_non_decreasing() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract_id, client) = setup(&env);
+    fund(&env, &contract_id, 1_000_000_000_000);
+
+    let mut prev_pool_size = load_stats(&env, &contract_id).pool_size;
+    let mut prev_mix_count = load_stats(&env, &contract_id).mix_count;
+
+    for i in 0..5u32 {
+        env.ledger().with_mut(|l| l.sequence_number += 1);
+        let player = Address::generate(&env);
+        client.start_game(&player, &Side::Heads, &10_000_000, &commitment(&env, i as u8 + 1));
+
+        let stats = load_stats(&env, &contract_id);
+        assert!(stats.pool_size >= prev_pool_size, "pool_size must not decrease");
+        assert!(stats.mix_count >= prev_mix_count, "mix_count must not decrease");
+        prev_pool_size = stats.pool_size;
+        prev_mix_count = stats.mix_count;
+    }
+}
+
+/// mix_count increments on continue_streak as well as start_game.
+#[test]
+fn test_mix_count_increments_on_continue_streak() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract_id, client) = setup(&env);
+    fund(&env, &contract_id, 1_000_000_000);
+
+    let player = Address::generate(&env);
+    client.start_game(&player, &Side::Heads, &10_000_000, &commitment(&env, 1));
+    let secret = soroban_sdk::Bytes::from_slice(&env, &[1u8; 32]);
+    assert_eq!(client.reveal(&player, &secret), true);
+
+    let before = load_stats(&env, &contract_id).mix_count;
+    env.ledger().with_mut(|l| l.sequence_number += 1);
+    client.continue_streak(&player, &commitment(&env, 2));
+    let after = load_stats(&env, &contract_id).mix_count;
+
+    assert_eq!(after, before + 1, "mix_count must increment on continue_streak");
+}

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -316,6 +316,8 @@ pub struct ContractConfig {
 /// - `reserve_balance`: Must always be sufficient to cover the worst-case payout (10x wager).
 ///   Decreases when players cash out or claim winnings (gross deducted), increases when players
 ///   lose and forfeit their wager.
+/// - `pool_size`: Monotonically increasing count of entropy contributions.
+/// - `mix_count`: Monotonically increasing count of entropy mix operations.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ContractStats {
@@ -328,6 +330,10 @@ pub struct ContractStats {
     /// Current contract reserve balance in stroops; decremented on payouts,
     /// incremented when the house wins (loss forfeiture).
     pub reserve_balance: i128,
+    /// Total number of entropy contributions accumulated into the pool.
+    pub pool_size: u64,
+    /// Total number of times entropy has been mixed into outcome generation.
+    pub mix_count: u64,
 }
 
 /// A single completed game record stored in a player's history ring-buffer.
@@ -365,6 +371,29 @@ pub struct HistoryEntry {
 /// Older entries are evicted in FIFO order once the cap is reached.
 pub const HISTORY_LIMIT: u32 = 100;
 
+/// Entropy pool accumulating randomness from multiple on-chain sources.
+///
+/// The pool is updated on every `start_game` and `continue_streak` call by
+/// XOR-folding the current ledger sequence and timestamp into the running
+/// 32-byte pool value.  The accumulated entropy is then mixed into outcome
+/// generation via XOR, making it harder for any single party to predict or
+/// bias the result.
+///
+/// Fields:
+/// - `pool`       – 32-byte running entropy accumulator
+/// - `pool_size`  – number of entropy contributions folded in so far
+/// - `mix_count`  – number of times the pool has been mixed into an outcome
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EntropyPool {
+    /// Running 32-byte entropy accumulator (XOR of all contributions).
+    pub pool: BytesN<32>,
+    /// Number of entropy contributions accumulated so far.
+    pub pool_size: u64,
+    /// Number of times the pool has been mixed into outcome generation.
+    pub mix_count: u64,
+}
+
 /// Persistent storage key variants for the contract's data model.
 ///
 /// Used with `env.storage().persistent()` for all reads and writes.
@@ -375,6 +404,8 @@ pub enum StorageKey {
     Config,
     /// Global aggregate statistics ([`ContractStats`]).
     Stats,
+    /// Global entropy pool ([`EntropyPool`]).
+    EntropyPool,
     /// Per-player game state ([`GameState`]), keyed by player address.
     PlayerGame(Address),
     /// Per-player game history ring-buffer ([`Vec<HistoryEntry>`]), keyed by player address.
@@ -622,12 +653,23 @@ impl CoinflipContract {
             total_volume: 0,
             total_fees: 0,
             reserve_balance: 0,
+            pool_size: 1, // seeded below with the ledger sequence hash
+            mix_count: 0,
         };
         
         env.storage().persistent().set(&StorageKey::Config, &config);
         env.storage().persistent().extend_ttl(&StorageKey::Config, TTL_THRESHOLD, TTL_EXTEND_TO);
         env.storage().persistent().set(&StorageKey::Stats, &stats);
         env.storage().persistent().extend_ttl(&StorageKey::Stats, TTL_THRESHOLD, TTL_EXTEND_TO);
+
+        // Initialize entropy pool with ledger sequence as the seed.
+        let seed_bytes = env.ledger().sequence().to_be_bytes();
+        let seed_hash: BytesN<32> = env.crypto().sha256(
+            &soroban_sdk::Bytes::from_slice(&env, &seed_bytes),
+        ).into();
+        let entropy = EntropyPool { pool: seed_hash, pool_size: 1, mix_count: 0 };
+        env.storage().persistent().set(&StorageKey::EntropyPool, &entropy);
+        env.storage().persistent().extend_ttl(&StorageKey::EntropyPool, TTL_THRESHOLD, TTL_EXTEND_TO);
         
         Ok(())
     }
@@ -720,6 +762,78 @@ impl CoinflipContract {
             .persistent()
             .get(&key)
             .unwrap_or_else(|| soroban_sdk::Vec::new(env))
+    }
+
+    /// Load the entropy pool. Returns a zero-seeded pool if none exists yet.
+    fn load_entropy_pool(env: &Env) -> EntropyPool {
+        let key = StorageKey::EntropyPool;
+        if env.storage().persistent().has(&key) {
+            env.storage().persistent().extend_ttl(&key, TTL_THRESHOLD, TTL_EXTEND_TO);
+            env.storage().persistent().get(&key).unwrap()
+        } else {
+            EntropyPool {
+                pool: BytesN::from_array(env, &[0u8; 32]),
+                pool_size: 0,
+                mix_count: 0,
+            }
+        }
+    }
+
+    /// Persist the entropy pool to permanent storage.
+    fn save_entropy_pool(env: &Env, entropy: &EntropyPool) {
+        env.storage().persistent().set(&StorageKey::EntropyPool, entropy);
+        env.storage().persistent().extend_ttl(&StorageKey::EntropyPool, TTL_THRESHOLD, TTL_EXTEND_TO);
+    }
+
+    /// Accumulate entropy from the current ledger sequence and timestamp.
+    ///
+    /// Folds `SHA-256(sequence || timestamp)` into the pool via XOR, then
+    /// increments `pool_size`.  Also updates `stats.pool_size`.
+    fn accumulate_entropy(env: &Env, stats: &mut ContractStats) {
+        let mut entropy = Self::load_entropy_pool(env);
+
+        // Build a 12-byte input: 4-byte sequence (big-endian) || 8-byte timestamp (big-endian)
+        let seq = env.ledger().sequence();
+        let ts  = env.ledger().timestamp();
+        let mut input = [0u8; 12];
+        input[..4].copy_from_slice(&seq.to_be_bytes());
+        input[4..].copy_from_slice(&ts.to_be_bytes());
+
+        let contribution: [u8; 32] = env.crypto()
+            .sha256(&soroban_sdk::Bytes::from_slice(env, &input))
+            .to_array();
+
+        // XOR the contribution into the pool.
+        let mut pool_arr = entropy.pool.to_array();
+        for i in 0..32 {
+            pool_arr[i] ^= contribution[i];
+        }
+        entropy.pool = BytesN::from_array(env, &pool_arr);
+        entropy.pool_size = entropy.pool_size.saturating_add(1);
+
+        Self::save_entropy_pool(env, &entropy);
+        stats.pool_size = entropy.pool_size;
+    }
+
+    /// Mix the entropy pool into a 32-byte value via XOR and increment `mix_count`.
+    ///
+    /// Returns the XOR of `base` and the current pool value.
+    /// Also updates `stats.mix_count`.
+    fn mix_entropy(env: &Env, base: &BytesN<32>, stats: &mut ContractStats) -> BytesN<32> {
+        let mut entropy = Self::load_entropy_pool(env);
+
+        let base_arr  = base.to_array();
+        let pool_arr  = entropy.pool.to_array();
+        let mut mixed = [0u8; 32];
+        for i in 0..32 {
+            mixed[i] = base_arr[i] ^ pool_arr[i];
+        }
+
+        entropy.mix_count = entropy.mix_count.saturating_add(1);
+        Self::save_entropy_pool(env, &entropy);
+        stats.mix_count = entropy.mix_count;
+
+        BytesN::from_array(env, &mixed)
     }
 
     /// Begin a new coinflip game for `player`.
@@ -816,9 +930,18 @@ impl CoinflipContract {
 
         // Generate contract-side randomness contribution from ledger sequence
         let seq_bytes = env.ledger().sequence().to_be_bytes();
-        let contract_random: BytesN<32> = env.crypto().sha256(
+        let base_random: BytesN<32> = env.crypto().sha256(
             &soroban_sdk::Bytes::from_slice(&env, &seq_bytes),
         ).into();
+
+        // Update global statistics to reflect a new active game creation.
+        // Accumulate entropy first so the mix below uses the freshest pool.
+        let mut stats = stats;
+        stats.total_games = stats.total_games.checked_add(1).unwrap_or(stats.total_games);
+        stats.total_volume = stats.total_volume.checked_add(wager).unwrap_or(stats.total_volume);
+        Self::accumulate_entropy(&env, &mut stats);
+        let contract_random = Self::mix_entropy(&env, &base_random, &mut stats);
+        Self::save_stats(&env, &stats);
 
         let game = GameState {
             wager,
@@ -832,12 +955,6 @@ impl CoinflipContract {
         };
 
         Self::save_player_game(&env, &player, &game);
-
-        // Update global statistics to reflect a new active game creation.
-        let mut stats = stats;
-        stats.total_games = stats.total_games.checked_add(1).unwrap_or(stats.total_games);
-        stats.total_volume = stats.total_volume.checked_add(wager).unwrap_or(stats.total_volume);
-        Self::save_stats(&env, &stats);
 
         Ok(())
     }
@@ -1229,9 +1346,15 @@ impl CoinflipContract {
 
         // Generate new contract randomness from the current ledger sequence
         let seq_bytes = env.ledger().sequence().to_be_bytes();
-        let contract_random: BytesN<32> = env.crypto().sha256(
+        let base_random: BytesN<32> = env.crypto().sha256(
             &soroban_sdk::Bytes::from_slice(&env, &seq_bytes),
         ).into();
+
+        // Accumulate entropy and mix into contract_random.
+        let mut stats = Self::load_stats(&env);
+        Self::accumulate_entropy(&env, &mut stats);
+        let contract_random = Self::mix_entropy(&env, &base_random, &mut stats);
+        Self::save_stats(&env, &stats);
 
         // Reset to Committed phase; preserve streak and wager
         game.phase = GamePhase::Committed;
@@ -1635,6 +1758,9 @@ mod statistics_tests;
 
 #[cfg(test)]
 mod admin_security_tests;
+
+#[cfg(test)]
+mod entropy_tests;
 
 #[cfg(test)]
 mod tests {

--- a/contract/src/snapshot_tests.rs
+++ b/contract/src/snapshot_tests.rs
@@ -107,6 +107,8 @@ fn contract_stats_zero() {
         total_volume: 0,
         total_fees: 0,
         reserve_balance: 0,
+        pool_size: 0,
+        mix_count: 0,
     };
     assert_snapshot!(borsh_to_hex(&env, &stats));
 }
@@ -119,6 +121,8 @@ fn contract_stats_production() {
         total_volume: 1_000_000_000_000, // 100k XLM volume
         total_fees: 30_000_000_000,       // 3% of volume
         reserve_balance: 500_000_000_000, // 50k XLM reserves
+        pool_size: 1_000_000,
+        mix_count: 1_000_000,
     };
     assert_snapshot!(borsh_to_hex(&env, &stats));
 }
@@ -131,6 +135,8 @@ fn contract_stats_roundtrip() {
         total_volume: 123_456_789,
         total_fees: 12_345_678,
         reserve_balance: 1_000_000_000,
+        pool_size: 42,
+        mix_count: 21,
     };
 
     let bytes = env.bytes_from_object(&original).unwrap().unwrap();
@@ -364,9 +370,11 @@ fn upgrade_simulation_stats_compatibility() {
     // Create stats with current schema
     let stats = ContractStats {
         total_games: 1000,
-        total_wins: 600,
-        total_losses: 400,
+        total_volume: 600_000_000,
+        total_fees: 18_000_000,
         reserve_balance: 50_000_000,
+        pool_size: 1000,
+        mix_count: 1000,
     };
     
     // Serialize
@@ -377,9 +385,11 @@ fn upgrade_simulation_stats_compatibility() {
     
     // Verify all fields preserved
     assert_eq!(deserialized.total_games, 1000);
-    assert_eq!(deserialized.total_wins, 600);
-    assert_eq!(deserialized.total_losses, 400);
+    assert_eq!(deserialized.total_volume, 600_000_000);
+    assert_eq!(deserialized.total_fees, 18_000_000);
     assert_eq!(deserialized.reserve_balance, 50_000_000);
+    assert_eq!(deserialized.pool_size, 1000);
+    assert_eq!(deserialized.mix_count, 1000);
 }
 
 // ── Storage Layout Versioning Strategy ───────────────────────────────────────


### PR DESCRIPTION
- Implement EntropyPool struct accumulating from ledger sequence + timestamp
- Add StorageKey::EntropyPool for persistent pool storage
- Mix entropy pool into contract_random via XOR in start_game and continue_streak
- Add pool_size and mix_count quality metrics to ContractStats
- Seed pool at initialize time with SHA-256(ledger_sequence)
- Add entropy_tests module: accumulation, mixing, and quality metric tests
- Fix snapshot_tests.rs ContractStats literals for new fields

closes #453 