### PR TITLE
Feat/randomness audit trail

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -666,6 +666,56 @@ pub fn verify_outcome_proof(env: &Env, proof: &OutcomeProof) -> bool {
     generate_outcome(env, &proof.secret, &proof.contract_random) == proof.outcome
 }
 
+/// A cryptographic audit trail for a single game's randomness generation.
+///
+/// Captures every step of the commit-reveal protocol so any observer can
+/// independently verify that the outcome was not manipulated by either party.
+///
+/// ## Verification steps (all reproducible with plain SHA-256)
+///
+/// 1. `SHA-256(secret) == commitment`
+///    — player was bound to their secret before `contract_random` was known
+/// 2. `SHA-256(ledger_sequence_bytes) == contract_random`
+///    — contract's contribution was fixed at game-start time
+/// 3. `SHA-256(secret || contract_random)[0] & 1` → outcome bit
+///    — neither party could unilaterally choose the result
+/// 4. `outcome == recorded_outcome`
+///    — the stored result matches the derivation
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RandomnessTrail {
+    /// Player's secret pre-image; reveals after game completion.
+    pub secret: Bytes,
+    /// SHA-256(secret); submitted before contract_random was known.
+    pub commitment: BytesN<32>,
+    /// SHA-256(ledger_sequence); fixed at game-start time.
+    pub contract_random: BytesN<32>,
+    /// Ledger sequence number at game creation; anchors contract_random.
+    pub ledger: u32,
+    /// Derived outcome: `SHA-256(secret || contract_random)[0] & 1`.
+    pub outcome: Side,
+    /// Whether the commitment → outcome chain verifies correctly.
+    pub valid: bool,
+}
+
+/// Verify the full randomness generation chain for a [`RandomnessTrail`].
+///
+/// Checks:
+/// 1. `SHA-256(trail.secret) == trail.commitment`
+/// 2. `generate_outcome(trail.secret, trail.contract_random) == trail.outcome`
+///
+/// Returns `false` immediately if `trail.secret` is empty (incomplete trail).
+/// This function is pure — no storage reads, no side effects.
+pub fn verify_randomness_trail(env: &Env, trail: &RandomnessTrail) -> bool {
+    if trail.secret.is_empty() {
+        return false;
+    }
+    if !verify_commitment(env, &trail.secret, &trail.commitment) {
+        return false;
+    }
+    generate_outcome(env, &trail.secret, &trail.contract_random) == trail.outcome
+}
+
 /// Provably fair coinflip game contract for the Stellar/Soroban platform.
 ///
 /// ## Public API
@@ -1730,6 +1780,48 @@ impl CoinflipContract {
             outcome: entry.outcome,
             side: entry.side,
             ledger: entry.ledger,
+        }))
+    }
+
+    /// Build a [`RandomnessTrail`] for a completed game in the player's history.
+    ///
+    /// Returns the full audit trail for the entry at `history_idx`, including
+    /// a pre-computed `valid` flag indicating whether the chain verifies.
+    /// Returns `None` when the entry's secret is empty (games settled via
+    /// `cash_out` do not re-store the secret after reveal).
+    ///
+    /// # Arguments
+    /// - `player`      – address whose history to inspect
+    /// - `history_idx` – index into the player's history buffer (0 = oldest)
+    ///
+    /// # Errors
+    /// - [`Error::NoActiveGame`] – no history exists for `player`
+    /// - [`Error::InvalidPhase`] – `history_idx` is out of range
+    pub fn get_randomness_trail(
+        env: Env,
+        player: Address,
+        history_idx: u32,
+    ) -> Result<Option<RandomnessTrail>, Error> {
+        let history = Self::load_player_history(&env, &player);
+        if history.is_empty() {
+            return Err(Error::NoActiveGame);
+        }
+        if history_idx >= history.len() {
+            return Err(Error::InvalidPhase);
+        }
+        let entry = history.get(history_idx).unwrap();
+        if entry.secret.is_empty() {
+            return Ok(None);
+        }
+        let valid = verify_commitment(&env, &entry.secret, &entry.commitment)
+            && generate_outcome(&env, &entry.secret, &entry.contract_random) == entry.outcome;
+        Ok(Some(RandomnessTrail {
+            secret: entry.secret,
+            commitment: entry.commitment,
+            contract_random: entry.contract_random,
+            outcome: entry.outcome,
+            ledger: entry.ledger,
+            valid,
         }))
     }
 
@@ -5828,6 +5920,229 @@ mod outcome_proof_property_tests {
 //   where fee_i = floor(gross_i * fee_bps_i / 10_000)
 //   and   gross_i = floor(wager_i * multiplier(streak_i) / 10_000)
 // ═══════════════════════════════════════════════════════════════════════════
+// Feature: randomness audit trail
+// Module:  randomness_audit_trail_tests
+// ═══════════════════════════════════════════════════════════════════════════
+#[cfg(test)]
+mod randomness_audit_trail_tests {
+    use super::*;
+    use proptest::prelude::*;
+    use soroban_sdk::testutils::Address as _;
+
+    fn setup(env: &Env) -> soroban_sdk::Address {
+        env.mock_all_auths();
+        let contract_id = env.register(CoinflipContract, ());
+        let client = CoinflipContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        let treasury = Address::generate(env);
+        let token = Address::generate(env);
+        client.initialize(&admin, &treasury, &token, &300, &1_000_000, &100_000_000);
+        contract_id
+    }
+
+    /// Inject a history entry with a known secret and return the expected trail.
+    fn inject_entry(env: &Env, contract_id: &soroban_sdk::Address, player: &Address, secret_bytes: &[u8]) -> RandomnessTrail {
+        let secret = Bytes::from_slice(env, secret_bytes);
+        let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
+        let contract_random: BytesN<32> = env.crypto().sha256(&Bytes::from_slice(env, &[55u8; 32])).into();
+        let outcome = generate_outcome(env, &secret, &contract_random);
+        env.as_contract(contract_id, || {
+            CoinflipContract::save_history_entry(env, player, HistoryEntry {
+                wager: 10_000_000, side: Side::Heads, outcome, won: outcome == Side::Heads,
+                streak: 1, commitment: commitment.clone(), secret: secret.clone(),
+                contract_random: contract_random.clone(), payout: 0, ledger: 42,
+            });
+        });
+        RandomnessTrail { secret, commitment, contract_random, outcome, ledger: 42, valid: true }
+    }
+
+    // ── verify_randomness_trail ──────────────────────────────────────────────
+
+    #[test]
+    fn test_valid_trail_verifies() {
+        let env = Env::default();
+        let secret = Bytes::from_slice(&env, &[3u8; 32]);
+        let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
+        let contract_random: BytesN<32> = env.crypto().sha256(&Bytes::from_slice(&env, &[7u8; 32])).into();
+        let outcome = generate_outcome(&env, &secret, &contract_random);
+        let trail = RandomnessTrail { secret, commitment, contract_random, outcome, ledger: 1, valid: false };
+        assert!(verify_randomness_trail(&env, &trail));
+    }
+
+    #[test]
+    fn test_empty_secret_fails() {
+        let env = Env::default();
+        let trail = RandomnessTrail {
+            secret: Bytes::new(&env),
+            commitment: BytesN::from_array(&env, &[0u8; 32]),
+            contract_random: BytesN::from_array(&env, &[0u8; 32]),
+            outcome: Side::Heads, ledger: 0, valid: false,
+        };
+        assert!(!verify_randomness_trail(&env, &trail));
+    }
+
+    #[test]
+    fn test_tampered_commitment_fails() {
+        let env = Env::default();
+        let secret = Bytes::from_slice(&env, &[3u8; 32]);
+        let contract_random: BytesN<32> = env.crypto().sha256(&Bytes::from_slice(&env, &[7u8; 32])).into();
+        let outcome = generate_outcome(&env, &secret, &contract_random);
+        let trail = RandomnessTrail {
+            secret,
+            commitment: BytesN::from_array(&env, &[0u8; 32]), // wrong
+            contract_random, outcome, ledger: 0, valid: false,
+        };
+        assert!(!verify_randomness_trail(&env, &trail));
+    }
+
+    #[test]
+    fn test_tampered_outcome_fails() {
+        let env = Env::default();
+        let secret = Bytes::from_slice(&env, &[3u8; 32]);
+        let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
+        let contract_random: BytesN<32> = env.crypto().sha256(&Bytes::from_slice(&env, &[7u8; 32])).into();
+        let real_outcome = generate_outcome(&env, &secret, &contract_random);
+        let flipped = match real_outcome { Side::Heads => Side::Tails, Side::Tails => Side::Heads };
+        let trail = RandomnessTrail { secret, commitment, contract_random, outcome: flipped, ledger: 0, valid: false };
+        assert!(!verify_randomness_trail(&env, &trail));
+    }
+
+    // ── get_randomness_trail ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_get_trail_returns_correct_data() {
+        let env = Env::default();
+        let contract_id = setup(&env);
+        let client = CoinflipContractClient::new(&env, &contract_id);
+        let player = Address::generate(&env);
+        let expected = inject_entry(&env, &contract_id, &player, &[3u8; 32]);
+
+        let trail = client.get_randomness_trail(&player, &0).unwrap().unwrap();
+        assert_eq!(trail.secret, expected.secret);
+        assert_eq!(trail.commitment, expected.commitment);
+        assert_eq!(trail.contract_random, expected.contract_random);
+        assert_eq!(trail.outcome, expected.outcome);
+        assert_eq!(trail.ledger, expected.ledger);
+        assert!(trail.valid);
+    }
+
+    #[test]
+    fn test_get_trail_valid_flag_is_true_for_honest_entry() {
+        let env = Env::default();
+        let contract_id = setup(&env);
+        let client = CoinflipContractClient::new(&env, &contract_id);
+        let player = Address::generate(&env);
+        inject_entry(&env, &contract_id, &player, &[3u8; 32]);
+        let trail = client.get_randomness_trail(&player, &0).unwrap().unwrap();
+        assert!(trail.valid);
+    }
+
+    #[test]
+    fn test_get_trail_no_history_returns_error() {
+        let env = Env::default();
+        let contract_id = setup(&env);
+        let client = CoinflipContractClient::new(&env, &contract_id);
+        let player = Address::generate(&env);
+        assert_eq!(client.try_get_randomness_trail(&player, &0), Err(Ok(Error::NoActiveGame)));
+    }
+
+    #[test]
+    fn test_get_trail_out_of_range_returns_error() {
+        let env = Env::default();
+        let contract_id = setup(&env);
+        let client = CoinflipContractClient::new(&env, &contract_id);
+        let player = Address::generate(&env);
+        inject_entry(&env, &contract_id, &player, &[3u8; 32]);
+        assert_eq!(client.try_get_randomness_trail(&player, &99), Err(Ok(Error::InvalidPhase)));
+    }
+
+    #[test]
+    fn test_get_trail_empty_secret_returns_none() {
+        let env = Env::default();
+        let contract_id = setup(&env);
+        let client = CoinflipContractClient::new(&env, &contract_id);
+        let player = Address::generate(&env);
+        let commitment: BytesN<32> = env.crypto().sha256(&Bytes::from_slice(&env, &[1u8; 32])).into();
+        let contract_random: BytesN<32> = env.crypto().sha256(&Bytes::from_slice(&env, &[2u8; 32])).into();
+        env.as_contract(&contract_id, || {
+            CoinflipContract::save_history_entry(&env, &player, HistoryEntry {
+                wager: 0, side: Side::Heads, outcome: Side::Heads, won: true,
+                streak: 1, commitment, secret: Bytes::new(&env), // empty
+                contract_random, payout: 0, ledger: 1,
+            });
+        });
+        assert_eq!(client.get_randomness_trail(&player, &0), None);
+    }
+
+    #[test]
+    fn test_multiple_entries_indexed_correctly() {
+        let env = Env::default();
+        let contract_id = setup(&env);
+        let client = CoinflipContractClient::new(&env, &contract_id);
+        let player = Address::generate(&env);
+        inject_entry(&env, &contract_id, &player, &[1u8; 32]);
+        inject_entry(&env, &contract_id, &player, &[2u8; 32]);
+
+        let t0 = client.get_randomness_trail(&player, &0).unwrap().unwrap();
+        let t1 = client.get_randomness_trail(&player, &1).unwrap().unwrap();
+        assert_ne!(t0.secret, t1.secret);
+        assert!(t0.valid);
+        assert!(t1.valid);
+    }
+
+    // ── property tests ───────────────────────────────────────────────────────
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(200))]
+
+        /// Any trail built from a valid (secret, contract_random) pair must verify.
+        #[test]
+        fn prop_valid_trail_always_verifies(
+            secret_bytes   in prop::array::uniform32(1u8..=255u8),
+            contract_bytes in prop::array::uniform32(any::<u8>()),
+        ) {
+            let env = soroban_sdk::Env::default();
+            let secret = Bytes::from_slice(&env, &secret_bytes);
+            let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
+            let contract_random: BytesN<32> = BytesN::from_array(&env, &contract_bytes);
+            let outcome = generate_outcome(&env, &secret, &contract_random);
+            let trail = RandomnessTrail { secret, commitment, contract_random, outcome, ledger: 0, valid: false };
+            prop_assert!(verify_randomness_trail(&env, &trail));
+        }
+
+        /// Flipping the outcome always causes verification to fail.
+        #[test]
+        fn prop_tampered_outcome_always_fails(
+            secret_bytes   in prop::array::uniform32(1u8..=255u8),
+            contract_bytes in prop::array::uniform32(any::<u8>()),
+        ) {
+            let env = soroban_sdk::Env::default();
+            let secret = Bytes::from_slice(&env, &secret_bytes);
+            let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
+            let contract_random: BytesN<32> = BytesN::from_array(&env, &contract_bytes);
+            let real = generate_outcome(&env, &secret, &contract_random);
+            let flipped = match real { Side::Heads => Side::Tails, Side::Tails => Side::Heads };
+            let trail = RandomnessTrail { secret, commitment, contract_random, outcome: flipped, ledger: 0, valid: false };
+            prop_assert!(!verify_randomness_trail(&env, &trail));
+        }
+
+        /// verify_randomness_trail is deterministic.
+        #[test]
+        fn prop_verification_is_deterministic(
+            secret_bytes   in prop::array::uniform32(1u8..=255u8),
+            contract_bytes in prop::array::uniform32(any::<u8>()),
+        ) {
+            let env = soroban_sdk::Env::default();
+            let secret = Bytes::from_slice(&env, &secret_bytes);
+            let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
+            let contract_random: BytesN<32> = BytesN::from_array(&env, &contract_bytes);
+            let outcome = generate_outcome(&env, &secret, &contract_random);
+            let trail = RandomnessTrail { secret, commitment, contract_random, outcome, ledger: 0, valid: false };
+            prop_assert_eq!(verify_randomness_trail(&env, &trail), verify_randomness_trail(&env, &trail));
+        }
+    }
+}
+
 // Feature: secure key derivation / commitment strength
 // Module:  commitment_strength_tests
 // ═══════════════════════════════════════════════════════════════════════════

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -534,6 +534,72 @@ pub fn generate_outcome(env: &Env, player_secret: &Bytes, contract_random: &Byte
     if hash.to_array()[0] % 2 == 0 { Side::Heads } else { Side::Tails }
 }
 
+/// A self-contained proof bundle that lets any party verify a game outcome
+/// without trusting the contract or any third party.
+///
+/// ## What this proves
+///
+/// Given `(secret, commitment, contract_random, outcome)`, any verifier can
+/// independently confirm:
+///
+/// 1. **Commitment integrity** – `SHA-256(secret) == commitment`
+///    The player locked their secret before the contract's randomness was known.
+///
+/// 2. **Outcome correctness** – `SHA-256(secret || contract_random)[0] & 1`
+///    determines the outcome bit; the recorded `outcome` matches.
+///
+/// Together these two checks prove that neither party could have unilaterally
+/// chosen the outcome: the player was bound by their commitment, and the
+/// contract's randomness was fixed at game-start time.
+///
+/// ## Privacy note
+///
+/// This is a *transparent* proof — the secret is included in plain text.
+/// The privacy guarantee comes from the commit-reveal protocol itself:
+/// the secret is only revealed *after* the outcome is already determined,
+/// so revealing it post-game leaks no exploitable information.
+///
+/// Off-chain verifiers can reproduce both checks using only standard SHA-256,
+/// with no dependency on the contract or the Stellar network.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OutcomeProof {
+    /// The player's revealed secret (pre-image of `commitment`).
+    pub secret: Bytes,
+    /// SHA-256 of `secret`; submitted before `contract_random` was known.
+    pub commitment: BytesN<32>,
+    /// SHA-256 of the ledger sequence at game-start time.
+    pub contract_random: BytesN<32>,
+    /// The derived outcome: `SHA-256(secret || contract_random)[0] & 1 == 0 → Heads`.
+    pub outcome: Side,
+    /// The player's chosen side; `won == (outcome == side)`.
+    pub side: Side,
+    /// Ledger sequence at game creation; anchors the proof to a specific block.
+    pub ledger: u32,
+}
+
+/// Verify an [`OutcomeProof`] without any on-chain state.
+///
+/// Performs both checks that constitute a complete outcome proof:
+///
+/// 1. `SHA-256(proof.secret) == proof.commitment`
+/// 2. `generate_outcome(proof.secret, proof.contract_random) == proof.outcome`
+///
+/// Returns `true` only when both checks pass.  Returns `false` if either
+/// check fails or if `proof.secret` is empty (proof is incomplete).
+///
+/// This function is pure — it reads no storage and has no side effects.
+/// It can be called by anyone, on-chain or off-chain, to audit any game.
+pub fn verify_outcome_proof(env: &Env, proof: &OutcomeProof) -> bool {
+    if proof.secret.is_empty() {
+        return false;
+    }
+    if !verify_commitment(env, &proof.secret, &proof.commitment) {
+        return false;
+    }
+    generate_outcome(env, &proof.secret, &proof.contract_random) == proof.outcome
+}
+
 /// Provably fair coinflip game contract for the Stellar/Soroban platform.
 ///
 /// ## Public API
@@ -1544,6 +1610,48 @@ impl CoinflipContract {
             result.push_back(history.get(i).unwrap());
         }
         result
+    }
+
+    /// Build an [`OutcomeProof`] for a completed game in the player's history.
+    ///
+    /// Returns the proof bundle for the entry at `history_idx`.  The proof
+    /// can be passed to [`verify_outcome_proof`] (or verified off-chain with
+    /// plain SHA-256) to confirm the outcome without trusting the contract.
+    ///
+    /// Returns `None` when the entry's secret is empty (games settled via
+    /// `cash_out` do not re-store the secret after reveal).
+    ///
+    /// # Arguments
+    /// - `player`      – address whose history to inspect
+    /// - `history_idx` – index into the player's history buffer (0 = oldest)
+    ///
+    /// # Errors
+    /// - [`Error::NoActiveGame`] – no history exists for `player`
+    /// - [`Error::InvalidPhase`] – `history_idx` is out of range
+    pub fn get_outcome_proof(
+        env: Env,
+        player: Address,
+        history_idx: u32,
+    ) -> Result<Option<OutcomeProof>, Error> {
+        let history = Self::load_player_history(&env, &player);
+        if history.is_empty() {
+            return Err(Error::NoActiveGame);
+        }
+        if history_idx >= history.len() {
+            return Err(Error::InvalidPhase);
+        }
+        let entry = history.get(history_idx).unwrap();
+        if entry.secret.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(OutcomeProof {
+            secret: entry.secret,
+            commitment: entry.commitment,
+            contract_random: entry.contract_random,
+            outcome: entry.outcome,
+            side: entry.side,
+            ledger: entry.ledger,
+        }))
     }
 
     /// Verify that a past game's outcome is reproducible from its stored proof.
@@ -5298,8 +5406,337 @@ mod property_tests {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Feature: soroban-coinflip-game
-// Module:  cumulative_fee_tests
+// Feature: outcome proof verification
+// Module:  outcome_proof_tests
+//
+// Validates OutcomeProof generation, verify_outcome_proof correctness, and
+// tamper-detection across all proof fields.
+// ═══════════════════════════════════════════════════════════════════════════
+#[cfg(test)]
+mod outcome_proof_tests {
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+
+    fn make_proof(env: &Env, secret_bytes: &[u8], side: Side) -> OutcomeProof {
+        let secret: Bytes = Bytes::from_slice(env, secret_bytes);
+        let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
+        let contract_random: BytesN<32> = env
+            .crypto()
+            .sha256(&Bytes::from_slice(env, &[99u8; 32]))
+            .into();
+        let outcome = generate_outcome(env, &secret, &contract_random);
+        OutcomeProof { secret, commitment, contract_random, outcome, side, ledger: 1 }
+    }
+
+    // ── verify_outcome_proof ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_valid_proof_verifies() {
+        let env = Env::default();
+        let proof = make_proof(&env, &[1u8; 32], Side::Heads);
+        assert!(verify_outcome_proof(&env, &proof));
+    }
+
+    #[test]
+    fn test_empty_secret_fails() {
+        let env = Env::default();
+        let mut proof = make_proof(&env, &[1u8; 32], Side::Heads);
+        proof.secret = Bytes::new(&env);
+        assert!(!verify_outcome_proof(&env, &proof));
+    }
+
+    #[test]
+    fn test_tampered_secret_fails() {
+        let env = Env::default();
+        let mut proof = make_proof(&env, &[1u8; 32], Side::Heads);
+        proof.secret = Bytes::from_slice(&env, &[2u8; 32]); // wrong secret
+        assert!(!verify_outcome_proof(&env, &proof));
+    }
+
+    #[test]
+    fn test_tampered_commitment_fails() {
+        let env = Env::default();
+        let mut proof = make_proof(&env, &[1u8; 32], Side::Heads);
+        proof.commitment = BytesN::from_array(&env, &[0u8; 32]); // wrong commitment
+        assert!(!verify_outcome_proof(&env, &proof));
+    }
+
+    #[test]
+    fn test_tampered_outcome_fails() {
+        let env = Env::default();
+        let mut proof = make_proof(&env, &[1u8; 32], Side::Heads);
+        // Flip the outcome to the opposite side
+        proof.outcome = match proof.outcome {
+            Side::Heads => Side::Tails,
+            Side::Tails => Side::Heads,
+        };
+        assert!(!verify_outcome_proof(&env, &proof));
+    }
+
+    #[test]
+    fn test_tampered_contract_random_fails() {
+        let env = Env::default();
+        let mut proof = make_proof(&env, &[1u8; 32], Side::Heads);
+        proof.contract_random = BytesN::from_array(&env, &[0u8; 32]); // wrong random
+        // outcome was derived from the original contract_random, so re-derivation
+        // with the tampered value will produce a different (or same) side — but
+        // the commitment check still passes; the outcome check may fail.
+        // We verify that the proof is no longer fully valid.
+        let recomputed = generate_outcome(&env, &proof.secret, &proof.contract_random);
+        // The proof is invalid if the recomputed outcome differs from the stored one.
+        // (If by coincidence they match, the proof would still pass — that's fine,
+        //  it just means the tampered random happened to produce the same bit.)
+        let expected = recomputed == proof.outcome;
+        assert_eq!(verify_outcome_proof(&env, &proof), expected);
+    }
+
+    // ── get_outcome_proof ────────────────────────────────────────────────────
+
+    /// Set up contract and return (env, contract_id).
+    fn setup_contract(env: &Env) -> soroban_sdk::Address {
+        env.mock_all_auths();
+        let contract_id = env.register(CoinflipContract, ());
+        let client = CoinflipContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        let treasury = Address::generate(env);
+        let token = Address::generate(env);
+        client.initialize(&admin, &treasury, &token, &300, &1_000_000, &100_000_000);
+        env.as_contract(&contract_id, || {
+            let mut stats = CoinflipContract::load_stats(env);
+            stats.reserve_balance = i128::MAX / 2;
+            CoinflipContract::save_stats(env, &stats);
+        });
+        contract_id
+    }
+
+    /// Inject a completed history entry with a known secret.
+    fn inject_history(env: &Env, contract_id: &soroban_sdk::Address, player: &Address, secret_bytes: &[u8]) -> OutcomeProof {
+        let secret = Bytes::from_slice(env, secret_bytes);
+        let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
+        let contract_random: BytesN<32> = env
+            .crypto()
+            .sha256(&Bytes::from_slice(env, &[77u8; 32]))
+            .into();
+        let outcome = generate_outcome(env, &secret, &contract_random);
+        let entry = HistoryEntry {
+            wager: 10_000_000,
+            side: Side::Heads,
+            outcome,
+            won: outcome == Side::Heads,
+            streak: 1,
+            commitment: commitment.clone(),
+            secret: secret.clone(),
+            contract_random: contract_random.clone(),
+            payout: 18_430_000,
+            ledger: 42,
+        };
+        env.as_contract(contract_id, || {
+            CoinflipContract::save_history_entry(env, player, entry);
+        });
+        OutcomeProof { secret, commitment, contract_random, outcome, side: Side::Heads, ledger: 42 }
+    }
+
+    #[test]
+    fn test_get_outcome_proof_returns_correct_proof() {
+        let env = Env::default();
+        let contract_id = setup_contract(&env);
+        let client = CoinflipContractClient::new(&env, &contract_id);
+        let player = Address::generate(&env);
+
+        let expected = inject_history(&env, &contract_id, &player, &[5u8; 32]);
+        let proof = client.get_outcome_proof(&player, &0).unwrap();
+
+        assert_eq!(proof.secret, expected.secret);
+        assert_eq!(proof.commitment, expected.commitment);
+        assert_eq!(proof.contract_random, expected.contract_random);
+        assert_eq!(proof.outcome, expected.outcome);
+        assert_eq!(proof.ledger, expected.ledger);
+    }
+
+    #[test]
+    fn test_get_outcome_proof_verifies() {
+        let env = Env::default();
+        let contract_id = setup_contract(&env);
+        let client = CoinflipContractClient::new(&env, &contract_id);
+        let player = Address::generate(&env);
+
+        inject_history(&env, &contract_id, &player, &[5u8; 32]);
+        let proof = client.get_outcome_proof(&player, &0).unwrap().unwrap();
+
+        // The returned proof must pass verify_outcome_proof.
+        assert!(verify_outcome_proof(&env, &proof));
+    }
+
+    #[test]
+    fn test_get_outcome_proof_no_history_returns_error() {
+        let env = Env::default();
+        let contract_id = setup_contract(&env);
+        let client = CoinflipContractClient::new(&env, &contract_id);
+        let player = Address::generate(&env);
+
+        let result = client.try_get_outcome_proof(&player, &0);
+        assert_eq!(result, Err(Ok(Error::NoActiveGame)));
+    }
+
+    #[test]
+    fn test_get_outcome_proof_out_of_range_returns_error() {
+        let env = Env::default();
+        let contract_id = setup_contract(&env);
+        let client = CoinflipContractClient::new(&env, &contract_id);
+        let player = Address::generate(&env);
+
+        inject_history(&env, &contract_id, &player, &[5u8; 32]);
+        let result = client.try_get_outcome_proof(&player, &99);
+        assert_eq!(result, Err(Ok(Error::InvalidPhase)));
+    }
+
+    #[test]
+    fn test_get_outcome_proof_empty_secret_returns_none() {
+        let env = Env::default();
+        let contract_id = setup_contract(&env);
+        let client = CoinflipContractClient::new(&env, &contract_id);
+        let player = Address::generate(&env);
+
+        // Inject a history entry with an empty secret (cash_out path).
+        let commitment: BytesN<32> = env
+            .crypto()
+            .sha256(&Bytes::from_slice(&env, &[1u8; 32]))
+            .into();
+        let contract_random: BytesN<32> = env
+            .crypto()
+            .sha256(&Bytes::from_slice(&env, &[2u8; 32]))
+            .into();
+        let entry = HistoryEntry {
+            wager: 10_000_000,
+            side: Side::Heads,
+            outcome: Side::Heads,
+            won: true,
+            streak: 1,
+            commitment,
+            secret: Bytes::new(&env), // empty — cash_out path
+            contract_random,
+            payout: 18_430_000,
+            ledger: 1,
+        };
+        env.as_contract(&contract_id, || {
+            CoinflipContract::save_history_entry(&env, &player, entry);
+        });
+
+        let result = client.get_outcome_proof(&player, &0);
+        assert_eq!(result, None);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Feature: outcome proof verification (property tests)
+// ═══════════════════════════════════════════════════════════════════════════
+#[cfg(test)]
+mod outcome_proof_property_tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(200))]
+
+        /// Any proof built from a valid (secret, contract_random) pair must verify.
+        #[test]
+        fn prop_valid_proof_always_verifies(
+            secret_bytes   in prop::array::uniform32(1u8..=255u8),
+            contract_bytes in prop::array::uniform32(any::<u8>()),
+        ) {
+            let env = soroban_sdk::Env::default();
+            let secret: Bytes = Bytes::from_slice(&env, &secret_bytes);
+            let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
+            let contract_random: BytesN<32> = BytesN::from_array(&env, &contract_bytes);
+            let outcome = generate_outcome(&env, &secret, &contract_random);
+            let proof = OutcomeProof {
+                secret, commitment, contract_random, outcome,
+                side: Side::Heads, ledger: 0,
+            };
+            prop_assert!(verify_outcome_proof(&env, &proof));
+        }
+
+        /// Flipping the outcome field always causes verification to fail.
+        #[test]
+        fn prop_tampered_outcome_always_fails(
+            secret_bytes   in prop::array::uniform32(1u8..=255u8),
+            contract_bytes in prop::array::uniform32(any::<u8>()),
+        ) {
+            let env = soroban_sdk::Env::default();
+            let secret: Bytes = Bytes::from_slice(&env, &secret_bytes);
+            let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
+            let contract_random: BytesN<32> = BytesN::from_array(&env, &contract_bytes);
+            let real_outcome = generate_outcome(&env, &secret, &contract_random);
+            let flipped = match real_outcome { Side::Heads => Side::Tails, Side::Tails => Side::Heads };
+            let proof = OutcomeProof {
+                secret, commitment, contract_random, outcome: flipped,
+                side: Side::Heads, ledger: 0,
+            };
+            prop_assert!(!verify_outcome_proof(&env, &proof));
+        }
+
+        /// A wrong secret (different from the one that produced the commitment)
+        /// always causes verification to fail.
+        #[test]
+        fn prop_wrong_secret_always_fails(
+            real_bytes  in prop::array::uniform32(1u8..=255u8),
+            wrong_bytes in prop::array::uniform32(1u8..=255u8),
+            contract_bytes in prop::array::uniform32(any::<u8>()),
+        ) {
+            prop_assume!(real_bytes != wrong_bytes);
+            let env = soroban_sdk::Env::default();
+            let real_secret: Bytes = Bytes::from_slice(&env, &real_bytes);
+            let wrong_secret: Bytes = Bytes::from_slice(&env, &wrong_bytes);
+            let commitment: BytesN<32> = env.crypto().sha256(&real_secret).into();
+            let contract_random: BytesN<32> = BytesN::from_array(&env, &contract_bytes);
+            let outcome = generate_outcome(&env, &real_secret, &contract_random);
+            let proof = OutcomeProof {
+                secret: wrong_secret, commitment, contract_random, outcome,
+                side: Side::Heads, ledger: 0,
+            };
+            prop_assert!(!verify_outcome_proof(&env, &proof));
+        }
+
+        /// An empty secret always causes verification to fail.
+        #[test]
+        fn prop_empty_secret_always_fails(
+            contract_bytes in prop::array::uniform32(any::<u8>()),
+        ) {
+            let env = soroban_sdk::Env::default();
+            let contract_random: BytesN<32> = BytesN::from_array(&env, &contract_bytes);
+            let proof = OutcomeProof {
+                secret: Bytes::new(&env),
+                commitment: BytesN::from_array(&env, &[0u8; 32]),
+                contract_random,
+                outcome: Side::Heads,
+                side: Side::Heads,
+                ledger: 0,
+            };
+            prop_assert!(!verify_outcome_proof(&env, &proof));
+        }
+
+        /// verify_outcome_proof is deterministic: same proof → same result.
+        #[test]
+        fn prop_verification_is_deterministic(
+            secret_bytes   in prop::array::uniform32(1u8..=255u8),
+            contract_bytes in prop::array::uniform32(any::<u8>()),
+        ) {
+            let env = soroban_sdk::Env::default();
+            let secret: Bytes = Bytes::from_slice(&env, &secret_bytes);
+            let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
+            let contract_random: BytesN<32> = BytesN::from_array(&env, &contract_bytes);
+            let outcome = generate_outcome(&env, &secret, &contract_random);
+            let proof = OutcomeProof {
+                secret, commitment, contract_random, outcome,
+                side: Side::Heads, ledger: 0,
+            };
+            prop_assert_eq!(
+                verify_outcome_proof(&env, &proof),
+                verify_outcome_proof(&env, &proof)
+            );
+        }
+    }
+}
 //
 // Verifies that `total_fees` in ContractStats accumulates correctly across
 // multiple sequential payouts and across fee_bps configuration changes.

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -52,6 +52,7 @@ use soroban_sdk::{contract, contractimpl, contracttype, contracterror, token, Ad
 /// | 13   | `RevealTimeout`              | Reveal         | (reserved for future timeout enforcement) |
 /// | 20   | `NoWinningsToClaimOrContinue`| Action         | `cash_out`, `claim_winnings`, `continue_streak` |
 /// | 21   | `InvalidCommitment`          | Action         | `continue_streak`                  |
+/// | 22   | `WeakCommitment`             | Action         | `start_game`, `continue_streak`    |
 /// | 30   | `Unauthorized`               | Admin          | `set_paused`, `set_treasury`, `set_wager_limits`, `set_fee` |
 /// | 31   | `InvalidFeePercentage`       | Admin          | `initialize`, `set_fee`            |
 /// | 32   | `InvalidWagerLimits`         | Admin          | `initialize`, `set_wager_limits`   |
@@ -72,9 +73,11 @@ pub mod error_codes {
     pub const COMMITMENT_MISMATCH: u32 = 12;
     pub const REVEAL_TIMEOUT: u32 = 13;
 
-    // Action errors (20–21)
+    // Action errors (20–22)
     pub const NO_WINNINGS_TO_CLAIM_OR_CONTINUE: u32 = 20;
     pub const INVALID_COMMITMENT: u32 = 21;
+    /// Commitment has insufficient entropy (all-same-byte or trivially weak pattern).
+    pub const WEAK_COMMITMENT: u32 = 22;
 
     // Admin errors (30–32)
     pub const UNAUTHORIZED: u32 = 30;
@@ -89,7 +92,7 @@ pub mod error_codes {
     pub const ALREADY_INITIALIZED: u32 = 51;
 
     /// Total number of defined error variants.
-    pub const VARIANT_COUNT: usize = 17;
+    pub const VARIANT_COUNT: usize = 18;
 }
 
 /// Error codes for the coinflip contract.
@@ -170,6 +173,13 @@ pub enum Error {
     /// Returned by: `continue_streak` (guard 4).
     /// Code: 21 — see [`error_codes::INVALID_COMMITMENT`]
     InvalidCommitment = 21,
+
+    /// Commitment has insufficient entropy (all-same-byte pattern).
+    /// A commitment where every byte is identical provides no randomness and
+    /// would allow a player to predict or bias outcomes.
+    /// Returned by: `start_game`, `continue_streak`.
+    /// Code: 22 — see [`error_codes::WEAK_COMMITMENT`]
+    WeakCommitment = 22,
 
     // ── Admin errors (30–32) ────────────────────────────────────────────────
 
@@ -496,6 +506,62 @@ pub fn calculate_payout(wager: i128, streak: u32, fee_bps: u32) -> Option<i128> 
 pub fn verify_commitment(env: &Env, secret: &Bytes, commitment: &BytesN<32>) -> bool {
     let hash: BytesN<32> = env.crypto().sha256(secret).into();
     &hash == commitment
+}
+
+/// Validates that a commitment has sufficient entropy to be secure.
+///
+/// A commitment is considered weak when all 32 bytes are identical — this
+/// pattern indicates a placeholder, a zeroed buffer, or a trivially
+/// constructed value that provides no randomness.  Such commitments could
+/// allow a player to predict or bias outcomes.
+///
+/// Returns `true` when the commitment passes the strength check (safe to use).
+/// Returns `false` when all bytes are the same (weak/placeholder).
+///
+/// ## Entropy requirement
+///
+/// A valid commitment must be the SHA-256 output of a secret with at least
+/// 128 bits of entropy.  SHA-256 produces 256-bit outputs; any output where
+/// all bytes are identical has probability 2^-248 under a uniform distribution,
+/// making it a reliable indicator of a non-random input.
+pub fn validate_commitment_strength(commitment: &BytesN<32>) -> bool {
+    let arr = commitment.to_array();
+    let first = arr[0];
+    // Reject if every byte equals the first byte (all-same pattern).
+    arr.iter().all(|&b| b == first) == false
+}
+
+/// Derives a commitment from a player secret using SHA-256 with domain separation.
+///
+/// ## Usage
+///
+/// Players should call this off-chain to generate their commitment before
+/// calling `start_game` or `continue_streak`.  The returned value is the
+/// commitment to submit on-chain; the `secret` must be kept private until
+/// the reveal step.
+///
+/// ## Domain separation
+///
+/// A fixed domain prefix `b"tossd:commitment:v1:"` is prepended to the secret
+/// before hashing.  This prevents cross-protocol hash collisions: a SHA-256
+/// output computed for a different purpose cannot be replayed as a valid
+/// Tossd commitment.
+///
+/// ## Security
+///
+/// The secret must have at least 128 bits of entropy (e.g. 16+ random bytes).
+/// Using a low-entropy secret (a short password, a counter, etc.) weakens the
+/// commit-reveal guarantee even though the hash itself is cryptographically
+/// sound.
+///
+/// # Arguments
+/// - `env`    – Soroban execution environment (needed for SHA-256)
+/// - `secret` – raw secret bytes; must be kept private until reveal
+pub fn derive_commitment(env: &Env, secret: &Bytes) -> BytesN<32> {
+    const DOMAIN: &[u8] = b"tossd:commitment:v1:";
+    let mut input = Bytes::from_slice(env, DOMAIN);
+    input.append(secret);
+    env.crypto().sha256(&input).into()
 }
 
 /// Deterministically derives a [`Side`] outcome from the player's revealed secret
@@ -870,7 +936,15 @@ impl CoinflipContract {
             }
         }
 
-        // Guard 5: reserves must cover the worst-case payout (streak 4+, no fee deduction)
+        // Guard 5: commitment must not be all-zero (placeholder) or all-same-byte (weak)
+        if commitment == BytesN::from_array(&env, &[0u8; 32]) {
+            return Err(Error::InvalidCommitment);
+        }
+        if !validate_commitment_strength(&commitment) {
+            return Err(Error::WeakCommitment);
+        }
+
+        // Guard 6: reserves must cover the worst-case payout (streak 4+, no fee deduction)
         let stats = Self::load_stats(&env);
         let max_payout = wager
             .checked_mul(MULTIPLIER_STREAK_4_PLUS as i128)
@@ -1277,6 +1351,11 @@ impl CoinflipContract {
         // Guard 4: commitment must not be all-zero bytes (missing / placeholder)
         if new_commitment == BytesN::from_array(&env, &[0u8; 32]) {
             return Err(Error::InvalidCommitment);
+        }
+
+        // Guard 4b: commitment must not be all-same-byte (weak / low-entropy)
+        if !validate_commitment_strength(&new_commitment) {
+            return Err(Error::WeakCommitment);
         }
 
         // Guard 5: reserves must cover the next streak's worst-case payout.
@@ -1874,6 +1953,7 @@ mod tests {
         assert_eq!(Error::RevealTimeout as u32, 13);
         assert_eq!(Error::NoWinningsToClaimOrContinue as u32, 20);
         assert_eq!(Error::InvalidCommitment as u32, 21);
+        assert_eq!(Error::WeakCommitment as u32, 22);
         assert_eq!(Error::Unauthorized as u32, 30);
         assert_eq!(Error::InvalidFeePercentage as u32, 31);
         assert_eq!(Error::InvalidWagerLimits as u32, 32);
@@ -5241,6 +5321,7 @@ mod property_tests {
             prop_assert_eq!(Error::RevealTimeout as u32, error_codes::REVEAL_TIMEOUT);
             prop_assert_eq!(Error::NoWinningsToClaimOrContinue as u32, error_codes::NO_WINNINGS_TO_CLAIM_OR_CONTINUE);
             prop_assert_eq!(Error::InvalidCommitment as u32, error_codes::INVALID_COMMITMENT);
+            prop_assert_eq!(Error::WeakCommitment as u32, error_codes::WEAK_COMMITMENT);
             prop_assert_eq!(Error::Unauthorized as u32, error_codes::UNAUTHORIZED);
             prop_assert_eq!(Error::InvalidFeePercentage as u32, error_codes::INVALID_FEE_PERCENTAGE);
             prop_assert_eq!(Error::InvalidWagerLimits as u32, error_codes::INVALID_WAGER_LIMITS);
@@ -5252,9 +5333,9 @@ mod property_tests {
         /// VARIANT_COUNT must exactly match the number of Error enum variants.
         #[test]
         fn prop_variant_count_is_accurate(_dummy in 0u32..100u32) {
-            // All 17 variants enumerated — if a new variant is added without
+            // All 18 variants enumerated — if a new variant is added without
             // updating VARIANT_COUNT, this list will need to grow.
-            let all_codes: [u32; 17] = [
+            let all_codes: [u32; 18] = [
                 error_codes::WAGER_BELOW_MINIMUM,
                 error_codes::WAGER_ABOVE_MAXIMUM,
                 error_codes::ACTIVE_GAME_EXISTS,
@@ -5266,6 +5347,7 @@ mod property_tests {
                 error_codes::REVEAL_TIMEOUT,
                 error_codes::NO_WINNINGS_TO_CLAIM_OR_CONTINUE,
                 error_codes::INVALID_COMMITMENT,
+                error_codes::WEAK_COMMITMENT,
                 error_codes::UNAUTHORIZED,
                 error_codes::INVALID_FEE_PERCENTAGE,
                 error_codes::INVALID_WAGER_LIMITS,
@@ -5745,6 +5827,215 @@ mod outcome_proof_property_tests {
 //   total_fees_after == total_fees_before + Σ fee_i
 //   where fee_i = floor(gross_i * fee_bps_i / 10_000)
 //   and   gross_i = floor(wager_i * multiplier(streak_i) / 10_000)
+// ═══════════════════════════════════════════════════════════════════════════
+// Feature: secure key derivation / commitment strength
+// Module:  commitment_strength_tests
+// ═══════════════════════════════════════════════════════════════════════════
+#[cfg(test)]
+mod commitment_strength_tests {
+    use super::*;
+    use proptest::prelude::*;
+    use soroban_sdk::testutils::Address as _;
+
+    // ── validate_commitment_strength ─────────────────────────────────────────
+
+    #[test]
+    fn test_all_zero_is_weak() {
+        assert!(!validate_commitment_strength(&BytesN::from_array(&Env::default(), &[0u8; 32])));
+    }
+
+    #[test]
+    fn test_all_same_byte_is_weak() {
+        let env = Env::default();
+        for b in [1u8, 0xffu8, 0x42u8] {
+            assert!(!validate_commitment_strength(&BytesN::from_array(&env, &[b; 32])));
+        }
+    }
+
+    #[test]
+    fn test_sha256_output_is_strong() {
+        let env = Env::default();
+        let secret = Bytes::from_slice(&env, &[1u8; 32]);
+        let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
+        assert!(validate_commitment_strength(&commitment));
+    }
+
+    #[test]
+    fn test_mixed_bytes_is_strong() {
+        let env = Env::default();
+        let mut arr = [0u8; 32];
+        arr[0] = 1;
+        assert!(validate_commitment_strength(&BytesN::from_array(&env, &arr)));
+    }
+
+    // ── derive_commitment ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_derive_commitment_is_deterministic() {
+        let env = Env::default();
+        let secret = Bytes::from_slice(&env, &[7u8; 32]);
+        assert_eq!(derive_commitment(&env, &secret), derive_commitment(&env, &secret));
+    }
+
+    #[test]
+    fn test_derive_commitment_differs_from_plain_sha256() {
+        let env = Env::default();
+        let secret = Bytes::from_slice(&env, &[7u8; 32]);
+        let plain: BytesN<32> = env.crypto().sha256(&secret).into();
+        assert_ne!(derive_commitment(&env, &secret), plain);
+    }
+
+    #[test]
+    fn test_derive_commitment_output_is_strong() {
+        let env = Env::default();
+        let secret = Bytes::from_slice(&env, &[7u8; 32]);
+        assert!(validate_commitment_strength(&derive_commitment(&env, &secret)));
+    }
+
+    #[test]
+    fn test_derive_commitment_different_secrets_differ() {
+        let env = Env::default();
+        let s1 = Bytes::from_slice(&env, &[1u8; 32]);
+        let s2 = Bytes::from_slice(&env, &[2u8; 32]);
+        assert_ne!(derive_commitment(&env, &s1), derive_commitment(&env, &s2));
+    }
+
+    // ── start_game rejects weak commitments ──────────────────────────────────
+
+    fn setup(env: &Env) -> (soroban_sdk::Address, CoinflipContractClient) {
+        env.mock_all_auths();
+        let contract_id = env.register(CoinflipContract, ());
+        let client = CoinflipContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        let treasury = Address::generate(env);
+        let token = Address::generate(env);
+        client.initialize(&admin, &treasury, &token, &300, &1_000_000, &100_000_000);
+        env.as_contract(&contract_id, || {
+            let mut stats = CoinflipContract::load_stats(env);
+            stats.reserve_balance = i128::MAX / 2;
+            CoinflipContract::save_stats(env, &stats);
+        });
+        (contract_id, client)
+    }
+
+    #[test]
+    fn test_start_game_rejects_all_zero_commitment() {
+        let env = Env::default();
+        let (_, client) = setup(&env);
+        let player = Address::generate(&env);
+        let result = client.try_start_game(
+            &player, &Side::Heads, &10_000_000,
+            &BytesN::from_array(&env, &[0u8; 32]),
+        );
+        assert_eq!(result, Err(Ok(Error::InvalidCommitment)));
+    }
+
+    #[test]
+    fn test_start_game_rejects_all_same_byte_commitment() {
+        let env = Env::default();
+        let (_, client) = setup(&env);
+        let player = Address::generate(&env);
+        let result = client.try_start_game(
+            &player, &Side::Heads, &10_000_000,
+            &BytesN::from_array(&env, &[0xffu8; 32]),
+        );
+        assert_eq!(result, Err(Ok(Error::WeakCommitment)));
+    }
+
+    #[test]
+    fn test_start_game_accepts_strong_commitment() {
+        let env = Env::default();
+        let (_, client) = setup(&env);
+        let player = Address::generate(&env);
+        let secret = Bytes::from_slice(&env, &[1u8; 32]);
+        let commitment = derive_commitment(&env, &secret);
+        assert!(client.try_start_game(&player, &Side::Heads, &10_000_000, &commitment).is_ok());
+    }
+
+    #[test]
+    fn test_continue_streak_rejects_weak_commitment() {
+        let env = Env::default();
+        let (contract_id, client) = setup(&env);
+        let player = Address::generate(&env);
+        let dummy: BytesN<32> = env.crypto().sha256(&Bytes::from_slice(&env, &[9u8; 32])).into();
+        let game = GameState {
+            wager: 10_000_000, side: Side::Heads, streak: 1,
+            commitment: dummy.clone(), contract_random: dummy,
+            fee_bps: 300, phase: GamePhase::Revealed, start_ledger: 0,
+        };
+        env.as_contract(&contract_id, || {
+            CoinflipContract::save_player_game(&env, &player, &game);
+        });
+        let result = client.try_continue_streak(
+            &player, &BytesN::from_array(&env, &[0xaau8; 32]),
+        );
+        assert_eq!(result, Err(Ok(Error::WeakCommitment)));
+    }
+
+    // ── error code stability ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_weak_commitment_error_code() {
+        assert_eq!(Error::WeakCommitment as u32, error_codes::WEAK_COMMITMENT);
+        assert_eq!(error_codes::WEAK_COMMITMENT, 22);
+    }
+
+    // ── property tests ───────────────────────────────────────────────────────
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(200))]
+
+        /// Any SHA-256 output used as a commitment must pass the strength check.
+        #[test]
+        fn prop_sha256_output_always_strong(
+            input in prop::array::uniform32(any::<u8>()),
+        ) {
+            let env = soroban_sdk::Env::default();
+            let bytes = Bytes::from_slice(&env, &input);
+            let commitment: BytesN<32> = env.crypto().sha256(&bytes).into();
+            prop_assert!(validate_commitment_strength(&commitment));
+        }
+
+        /// derive_commitment output always passes the strength check.
+        #[test]
+        fn prop_derive_commitment_always_strong(
+            secret_bytes in prop::array::uniform32(any::<u8>()),
+        ) {
+            let env = soroban_sdk::Env::default();
+            let secret = Bytes::from_slice(&env, &secret_bytes);
+            prop_assert!(validate_commitment_strength(&derive_commitment(&env, &secret)));
+        }
+
+        /// All-same-byte arrays are always weak.
+        #[test]
+        fn prop_all_same_byte_always_weak(byte in any::<u8>()) {
+            let env = soroban_sdk::Env::default();
+            prop_assert!(!validate_commitment_strength(&BytesN::from_array(&env, &[byte; 32])));
+        }
+
+        /// derive_commitment is deterministic across calls.
+        #[test]
+        fn prop_derive_commitment_deterministic(
+            secret_bytes in prop::array::uniform32(any::<u8>()),
+        ) {
+            let env = soroban_sdk::Env::default();
+            let secret = Bytes::from_slice(&env, &secret_bytes);
+            prop_assert_eq!(derive_commitment(&env, &secret), derive_commitment(&env, &secret));
+        }
+
+        /// derive_commitment with domain separation differs from plain SHA-256.
+        #[test]
+        fn prop_derive_commitment_differs_from_plain_sha256(
+            secret_bytes in prop::array::uniform32(any::<u8>()),
+        ) {
+            let env = soroban_sdk::Env::default();
+            let secret = Bytes::from_slice(&env, &secret_bytes);
+            let plain: BytesN<32> = env.crypto().sha256(&secret).into();
+            prop_assert_ne!(derive_commitment(&env, &secret), plain);
+        }
+    }
+}
+
 //
 // Properties:
 //   P-1  After N sequential cash-outs, total_fees equals the sum of each


### PR DESCRIPTION
closes #455 

What was built and why:                                                                            
                                                                                                     
  The key design decision: no new storage. Every field needed for a complete randomness audit trail  
  (secret, commitment, contract_random, ledger, outcome) is already stored in HistoryEntry. Adding a 
  separate audit trail store would duplicate data and double the storage cost per game — a           
  significant concern on Soroban where storage fees are real.                                        
                                                                                                     
  `RandomnessTrail` struct — packages the audit-relevant fields plus a pre-computed valid flag. The  
  valid field lets callers check integrity in a single query without a second round-trip.            
                                                                                                     
  `verify_randomness_trail(env, trail)` — pure function (no storage reads) that validates the full   
  chain: SHA-256(secret) == commitment and generate_outcome(secret, contract_random) == outcome. Any 
  observer can reproduce this off-chain with plain SHA-256.                                          
                                                                                                     
  `get_randomness_trail(player, history_idx)` — query method that reads from the existing            
  PlayerHistory ring-buffer, computes valid inline, and returns None for entries without a stored    
  secret (cash-out path). Same error semantics as get_outcome_proof.                                 
                                                                                                     
  Tests: 8 unit tests (valid trail, empty secret, tampered commitment, tampered outcome, no history, 
  out-of-range, empty secret returns None, multiple entries indexed correctly) + 3 property tests    
  (valid always verifies, tampered outcome always fails, determinism).