### PR TITLE
Feat/anti frontrunning protection

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -59,6 +59,7 @@ use soroban_sdk::{contract, contractimpl, contracttype, contracterror, token, Ad
 /// | 40   | `TransferFailed`             | Transfer       | `claim_winnings`                   |
 /// | 50   | `AdminTreasuryConflict`      | Initialization | `initialize`                       |
 /// | 51   | `AlreadyInitialized`         | Initialization | `initialize`                       |
+/// | 60   | `RevealTooEarly`             | Front-running  | `reveal`                           |
 pub mod error_codes {
     // Game creation errors (1–5)
     pub const WAGER_BELOW_MINIMUM: u32 = 1;
@@ -91,8 +92,12 @@ pub mod error_codes {
     pub const ADMIN_TREASURY_CONFLICT: u32 = 50;
     pub const ALREADY_INITIALIZED: u32 = 51;
 
+    // Front-running protection (60)
+    /// Reveal attempted in the same ledger as game start; must wait at least one ledger.
+    pub const REVEAL_TOO_EARLY: u32 = 60;
+
     /// Total number of defined error variants.
-    pub const VARIANT_COUNT: usize = 18;
+    pub const VARIANT_COUNT: usize = 19;
 }
 
 /// Error codes for the coinflip contract.
@@ -216,6 +221,23 @@ pub enum Error {
     /// Returned by: `initialize`.
     /// Code: 51 — see [`error_codes::ALREADY_INITIALIZED`]
     AlreadyInitialized = 51,
+
+    // ── Front-running protection (60) ───────────────────────────────────────
+
+    /// Reveal was attempted in the same ledger as `start_game` (or `continue_streak`).
+    ///
+    /// `contract_random = SHA-256(ledger_sequence)` is fixed per ledger.  If a
+    /// player could submit `start_game` and `reveal` in the same ledger they
+    /// could observe the ledger sequence before it closes, pre-compute the
+    /// outcome, and only submit the reveal when it is favourable.
+    ///
+    /// Requiring at least one ledger between commitment and reveal closes this
+    /// window: by the time the reveal ledger is being built, `contract_random`
+    /// is already immutably committed on-chain.
+    ///
+    /// Returned by: `reveal`.
+    /// Code: 60 — see [`error_codes::REVEAL_TOO_EARLY`]
+    RevealTooEarly = 60,
 }
 
 /// The player's chosen side for a coinflip.
@@ -427,6 +449,15 @@ const TTL_EXTEND_TO: u32 = 500_000;
 /// Number of ledgers a player has to call `reveal` before the wager can be
 /// reclaimed via `reclaim_wager`.  At ~5 s/ledger this is roughly 8 minutes.
 const REVEAL_TIMEOUT_LEDGERS: u32 = 100;
+
+/// Minimum ledger gap between `start_game` (or `continue_streak`) and `reveal`.
+///
+/// Prevents same-ledger front-running: if both transactions land in the same
+/// ledger, the player could have observed `ledger_sequence` before it closed
+/// and crafted a secret that produces a winning outcome.  Requiring the reveal
+/// to be in a strictly later ledger ensures `contract_random` is already
+/// immutably committed before the reveal is submitted.
+const MIN_REVEAL_DELAY: u32 = 1;
 
 /// Returns the gross payout multiplier (in basis points, 10_000 = 1x)
 /// for the given win `streak` level.
@@ -1094,6 +1125,15 @@ impl CoinflipContract {
             return Err(Error::CommitmentMismatch);
         }
 
+        // Guard 4: reveal must be in a strictly later ledger than start_game.
+        // contract_random = SHA-256(ledger_sequence) is fixed per ledger.  A
+        // player who submits start_game and reveal in the same ledger could
+        // observe the sequence before the ledger closes and pre-compute a
+        // winning secret.  This guard closes that window.
+        if env.ledger().sequence() <= game.start_ledger {
+            return Err(Error::RevealTooEarly);
+        }
+
         // Determine outcome by combining player secret + contract random
         let outcome = generate_outcome(&env, &secret, &game.contract_random);
 
@@ -1432,6 +1472,8 @@ impl CoinflipContract {
         game.phase = GamePhase::Committed;
         game.commitment = new_commitment;
         game.contract_random = contract_random.into();
+        // Refresh start_ledger so the RevealTooEarly guard applies to the next reveal.
+        game.start_ledger = env.ledger().sequence();
 
         Self::save_player_game(&env, &player, &game);
 
@@ -2052,6 +2094,7 @@ mod tests {
         assert_eq!(Error::TransferFailed as u32, 40);
         assert_eq!(Error::AdminTreasuryConflict as u32, 50);
         assert_eq!(Error::AlreadyInitialized as u32, 51);
+        assert_eq!(Error::RevealTooEarly as u32, 60);
     }
 
     #[test]
@@ -2983,6 +3026,7 @@ mod tests {
         let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
 
         client.start_game(&player, &Side::Heads, &10_000_000, &commitment);
+        env.ledger().with_mut(|l| l.sequence_number += 1);
         assert_eq!(client.try_reveal(&player, &secret), Ok(true));
 
         // Fee changes after reveal must not alter this game's payout terms.
@@ -3008,6 +3052,7 @@ mod tests {
         let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
 
         client.start_game(&player, &Side::Heads, &10_000_000, &commitment);
+        env.ledger().with_mut(|l| l.sequence_number += 1);
         assert_eq!(client.try_reveal(&player, &secret), Ok(true));
 
         let expected = calculate_payout(10_000_000, 1, 500).unwrap();
@@ -4042,6 +4087,7 @@ mod property_tests {
             let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
 
             client.start_game(&player, &Side::Heads, &wager, &commitment);
+            env.ledger().with_mut(|l| l.sequence_number += 1);
             prop_assert_eq!(client.try_reveal(&player, &secret), Ok(true));
 
             let revealed: GameState = env.as_contract(&contract_id, || {
@@ -4094,6 +4140,7 @@ mod property_tests {
             let secret_one = Bytes::from_slice(&env, &[1u8; 32]);
             let commitment_one: BytesN<32> = env.crypto().sha256(&secret_one).into();
             client.start_game(&player_one, &Side::Heads, &wager, &commitment_one);
+            env.ledger().with_mut(|l| l.sequence_number += 1);
             prop_assert_eq!(client.try_reveal(&player_one, &secret_one), Ok(true));
 
             // Admin updates fee; this must only affect newly created games.
@@ -4395,6 +4442,7 @@ mod property_tests {
         let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
 
         client.start_game(&player, &Side::Heads, &wager, &commitment);
+        env.ledger().with_mut(|l| l.sequence_number += 1);
         client.reveal(&player, &secret);
 
         (admin, treasury, token, contract_id, player)
@@ -4517,6 +4565,7 @@ mod property_tests {
             let secret2 = Bytes::from_slice(&env, &[1u8; 32]);
             let commitment2: BytesN<32> = env.crypto().sha256(&secret2).into();
             client.start_game(&player2, &Side::Heads, &wager2, &commitment2);
+            env.ledger().with_mut(|l| l.sequence_number += 1);
             client.reveal(&player2, &secret2);
 
             // Record initial balances
@@ -4629,6 +4678,7 @@ mod property_tests {
             let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
 
             client.start_game(&player, &Side::Heads, &wager, &commitment);
+            env.ledger().with_mut(|l| l.sequence_number += 1);
             client.reveal(&player, &secret);
 
             let pre_stats: ContractStats = env.as_contract(&contract_id, || {
@@ -5420,6 +5470,7 @@ mod property_tests {
             prop_assert_eq!(Error::TransferFailed as u32, error_codes::TRANSFER_FAILED);
             prop_assert_eq!(Error::AdminTreasuryConflict as u32, error_codes::ADMIN_TREASURY_CONFLICT);
             prop_assert_eq!(Error::AlreadyInitialized as u32, error_codes::ALREADY_INITIALIZED);
+            prop_assert_eq!(Error::RevealTooEarly as u32, error_codes::REVEAL_TOO_EARLY);
         }
 
         /// VARIANT_COUNT must exactly match the number of Error enum variants.
@@ -5427,7 +5478,7 @@ mod property_tests {
         fn prop_variant_count_is_accurate(_dummy in 0u32..100u32) {
             // All 18 variants enumerated — if a new variant is added without
             // updating VARIANT_COUNT, this list will need to grow.
-            let all_codes: [u32; 18] = [
+            let all_codes: [u32; 19] = [
                 error_codes::WAGER_BELOW_MINIMUM,
                 error_codes::WAGER_ABOVE_MAXIMUM,
                 error_codes::ACTIVE_GAME_EXISTS,
@@ -5446,6 +5497,7 @@ mod property_tests {
                 error_codes::TRANSFER_FAILED,
                 error_codes::ADMIN_TREASURY_CONFLICT,
                 error_codes::ALREADY_INITIALIZED,
+                error_codes::REVEAL_TOO_EARLY,
             ];
             prop_assert_eq!(all_codes.len(), error_codes::VARIANT_COUNT);
         }
@@ -5919,6 +5971,128 @@ mod outcome_proof_property_tests {
 //   total_fees_after == total_fees_before + Σ fee_i
 //   where fee_i = floor(gross_i * fee_bps_i / 10_000)
 //   and   gross_i = floor(wager_i * multiplier(streak_i) / 10_000)
+// ═══════════════════════════════════════════════════════════════════════════
+// Feature: anti-front-running protection
+// Module:  anti_frontrunning_tests
+// ═══════════════════════════════════════════════════════════════════════════
+#[cfg(test)]
+mod anti_frontrunning_tests {
+    use super::*;
+    use soroban_sdk::testutils::{Address as _, Ledger};
+
+    fn setup(env: &Env) -> (soroban_sdk::Address, CoinflipContractClient) {
+        env.mock_all_auths();
+        let contract_id = env.register(CoinflipContract, ());
+        let client = CoinflipContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        let treasury = Address::generate(env);
+        let token = Address::generate(env);
+        client.initialize(&admin, &treasury, &token, &300, &1_000_000, &100_000_000);
+        env.as_contract(&contract_id, || {
+            let mut stats = CoinflipContract::load_stats(env);
+            stats.reserve_balance = i128::MAX / 2;
+            CoinflipContract::save_stats(env, &stats);
+        });
+        (contract_id, client)
+    }
+
+    fn strong_commitment(env: &Env, seed: u8) -> (Bytes, BytesN<32>) {
+        let secret = Bytes::from_slice(env, &[seed; 32]);
+        let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
+        (secret, commitment)
+    }
+
+    // ── Same-ledger reveal is rejected ───────────────────────────────────────
+
+    #[test]
+    fn test_reveal_same_ledger_as_start_rejected() {
+        let env = Env::default();
+        let (_, client) = setup(&env);
+        let player = Address::generate(&env);
+        let (secret, commitment) = strong_commitment(&env, 1);
+
+        client.start_game(&player, &Side::Heads, &10_000_000, &commitment);
+        // No ledger advance — same ledger as start_game
+        let result = client.try_reveal(&player, &secret);
+        assert_eq!(result, Err(Ok(Error::RevealTooEarly)));
+    }
+
+    #[test]
+    fn test_reveal_next_ledger_succeeds() {
+        let env = Env::default();
+        let (_, client) = setup(&env);
+        let player = Address::generate(&env);
+        let (secret, commitment) = strong_commitment(&env, 1);
+
+        client.start_game(&player, &Side::Heads, &10_000_000, &commitment);
+        env.ledger().with_mut(|l| l.sequence_number += 1);
+        // One ledger later — must succeed
+        assert!(client.try_reveal(&player, &secret).is_ok());
+    }
+
+    #[test]
+    fn test_reveal_many_ledgers_later_succeeds() {
+        let env = Env::default();
+        let (_, client) = setup(&env);
+        let player = Address::generate(&env);
+        let (secret, commitment) = strong_commitment(&env, 1);
+
+        client.start_game(&player, &Side::Heads, &10_000_000, &commitment);
+        env.ledger().with_mut(|l| l.sequence_number += 50);
+        assert!(client.try_reveal(&player, &secret).is_ok());
+    }
+
+    // ── continue_streak refreshes start_ledger ───────────────────────────────
+
+    #[test]
+    fn test_reveal_after_continue_same_ledger_rejected() {
+        let env = Env::default();
+        let (contract_id, client) = setup(&env);
+        let player = Address::generate(&env);
+        let (secret1, commitment1) = strong_commitment(&env, 1);
+
+        client.start_game(&player, &Side::Heads, &10_000_000, &commitment1);
+        env.ledger().with_mut(|l| l.sequence_number += 1);
+        client.reveal(&player, &secret1); // win
+
+        // continue_streak in ledger N
+        let (_, commitment2) = strong_commitment(&env, 2);
+        client.continue_streak(&player, &commitment2);
+
+        // Reveal in the same ledger as continue_streak — must be rejected
+        let secret2 = Bytes::from_slice(&env, &[2u8; 32]);
+        let result = client.try_reveal(&player, &secret2);
+        assert_eq!(result, Err(Ok(Error::RevealTooEarly)));
+    }
+
+    #[test]
+    fn test_reveal_after_continue_next_ledger_succeeds() {
+        let env = Env::default();
+        let (contract_id, client) = setup(&env);
+        let player = Address::generate(&env);
+        let (secret1, commitment1) = strong_commitment(&env, 1);
+
+        client.start_game(&player, &Side::Heads, &10_000_000, &commitment1);
+        env.ledger().with_mut(|l| l.sequence_number += 1);
+        client.reveal(&player, &secret1); // win
+
+        let (_, commitment2) = strong_commitment(&env, 2);
+        client.continue_streak(&player, &commitment2);
+        env.ledger().with_mut(|l| l.sequence_number += 1);
+
+        let secret2 = Bytes::from_slice(&env, &[2u8; 32]);
+        assert!(client.try_reveal(&player, &secret2).is_ok());
+    }
+
+    // ── Error code stability ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_reveal_too_early_error_code() {
+        assert_eq!(Error::RevealTooEarly as u32, error_codes::REVEAL_TOO_EARLY);
+        assert_eq!(error_codes::REVEAL_TOO_EARLY, 60);
+    }
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Feature: randomness audit trail
 // Module:  randomness_audit_trail_tests
@@ -7283,6 +7457,7 @@ mod loss_forfeiture_tests {
             client.start_game(&player, &side, &wager, &commitment);
 
             // LF-1: must return false
+            env.ledger().with_mut(|l| l.sequence_number += 1);
             let result = client.reveal(&player, &secret);
             prop_assert!(!result, "reveal must return false on a loss");
 
@@ -7323,6 +7498,7 @@ mod loss_forfeiture_tests {
             let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
 
             client.start_game(&player, &side, &wager, &commitment);
+            env.ledger().with_mut(|l| l.sequence_number += 1);
             client.reveal(&player, &secret);
 
             let reserves_after: i128 = env.as_contract(&contract_id, || {
@@ -7359,6 +7535,7 @@ mod loss_forfeiture_tests {
             let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
 
             client.start_game(&player, &side, &wager, &commitment);
+            env.ledger().with_mut(|l| l.sequence_number += 1);
             client.reveal(&player, &secret);
 
             // LF-4: new game must be accepted
@@ -7401,6 +7578,7 @@ mod loss_forfeiture_tests {
             let secret_h = loss_secret_for_side(&env_h, &Side::Heads);
             let commitment_h: BytesN<32> = env_h.crypto().sha256(&secret_h).into();
             client_h.start_game(&player_h, &Side::Heads, &wager, &commitment_h);
+            env_h.ledger().with_mut(|l| l.sequence_number += 1);
             client_h.reveal(&player_h, &secret_h);
             let delta_h = env_h.as_contract(&contract_id_h, || {
                 CoinflipContract::load_stats(&env_h).reserve_balance
@@ -7416,6 +7594,7 @@ mod loss_forfeiture_tests {
             let secret_t = loss_secret_for_side(&env_t, &Side::Tails);
             let commitment_t: BytesN<32> = env_t.crypto().sha256(&secret_t).into();
             client_t.start_game(&player_t, &Side::Tails, &wager, &commitment_t);
+            env_t.ledger().with_mut(|l| l.sequence_number += 1);
             client_t.reveal(&player_t, &secret_t);
             let delta_t = env_t.as_contract(&contract_id_t, || {
                 CoinflipContract::load_stats(&env_t).reserve_balance
@@ -7735,6 +7914,7 @@ mod reserve_solvency_tests {
         let commitment = env.crypto().sha256(&secret).into();
         
         client.start_game(&player, &Side::Heads, &wager, &commitment);
+        env.ledger().with_mut(|l| l.sequence_number += 1);
         client.reveal(&player, &secret);
         
         // Now game is in Revealed (streak 1). Next streak is 2. Multiplier for 2 is 3.5x.
@@ -7842,6 +8022,7 @@ mod reserve_balance_accuracy_tests {
 
             client.start_game(&player, &Side::Heads, &wager, &commitment);
             let before = reserve(&env, &id);
+            env.ledger().with_mut(|l| l.sequence_number += 1);
             client.reveal(&player, &secret);
             let after = reserve(&env, &id);
 
@@ -7865,6 +8046,7 @@ mod reserve_balance_accuracy_tests {
             let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
 
             client.start_game(&player, &Side::Heads, &wager, &commitment);
+            env.ledger().with_mut(|l| l.sequence_number += 1);
             client.reveal(&player, &secret);
             // streak = 1 after win
             let gross = wager.checked_mul(get_multiplier(1) as i128) / 10_000;
@@ -7913,6 +8095,7 @@ mod reserve_balance_accuracy_tests {
             let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
 
             client.start_game(&player, &Side::Heads, &wager, &commitment);
+            env.ledger().with_mut(|l| l.sequence_number += 1);
             client.reveal(&player, &secret);
             client.cash_out(&player);
 
@@ -7939,12 +8122,14 @@ mod reserve_balance_accuracy_tests {
             let loss_sec = loss_secret(&env);
             let loss_com: BytesN<32> = env.crypto().sha256(&loss_sec).into();
             client.start_game(&p_loss, &Side::Heads, &wager, &loss_com);
+            env.ledger().with_mut(|l| l.sequence_number += 1);
             client.reveal(&p_loss, &loss_sec);
 
             // Win game
             let win_sec = win_secret(&env);
             let win_com: BytesN<32> = env.crypto().sha256(&win_sec).into();
             client.start_game(&p_win, &Side::Heads, &wager, &win_com);
+            env.ledger().with_mut(|l| l.sequence_number += 1);
             client.reveal(&p_win, &win_sec);
             let gross_win = wager.checked_mul(get_multiplier(1) as i128) / 10_000;
 
@@ -8021,6 +8206,7 @@ mod reserve_balance_accuracy_tests {
             let secret = loss_secret(&env);
             let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
             client.start_game(&player, &Side::Heads, &wager, &commitment);
+            env.ledger().with_mut(|l| l.sequence_number += 1);
             client.reveal(&player, &secret);
         }
 
@@ -8071,6 +8257,7 @@ mod concurrency_edge_case_tests {
 
         // Game 1: start -> reveal (win) -> cash_out (no real token needed)
         client.start_game(&player, &Side::Heads, &min_wager, &commitment);
+        env.ledger().with_mut(|l| l.sequence_number += 1);
         client.reveal(&player, &secret);
         client.cash_out(&player);
 
@@ -8092,6 +8279,7 @@ mod concurrency_edge_case_tests {
 
         // Game 1: start -> reveal (win) -> cash_out
         client.start_game(&player, &Side::Heads, &min_wager, &commitment);
+        env.ledger().with_mut(|l| l.sequence_number += 1);
         client.reveal(&player, &secret);
         let payout = client.try_cash_out(&player);
         assert!(payout.is_ok());
@@ -8115,6 +8303,7 @@ mod concurrency_edge_case_tests {
         client.start_game(&player, &Side::Heads, &min_wager, &commitment);
 
         // First reveal succeeds
+        env.ledger().with_mut(|l| l.sequence_number += 1);
         client.reveal(&player, &secret);
 
         // Second reveal fails with InvalidPhase because game moved to Revealed phase
@@ -8355,7 +8544,11 @@ mod integration_tests {
         ) -> bool {
             let commitment = self.make_commitment(seed);
             self.client.start_game(player, &side, &wager, &commitment);
+            // Advance one ledger so reveal is in a strictly later ledger than
+            // start_game (anti-front-running guard).
+            self.env.ledger().with_mut(|l| l.sequence_number += 1);
             let secret = self.make_secret(seed);
+            env.ledger().with_mut(|l| l.sequence_number += 1);
             self.client.reveal(player, &secret)
         }
 
@@ -8442,6 +8635,7 @@ mod integration_tests {
         h.client.continue_streak(&player, &new_commitment);
         assert_eq!(h.game_state(&player).phase, GamePhase::Committed);
         let secret2 = h.make_secret(1);
+        env.ledger().with_mut(|l| l.sequence_number += 1);
         let won2 = h.client.reveal(&player, &secret2);
         assert!(won2, "round 2 must win");
         assert_eq!(h.game_state(&player).streak, 2);
@@ -8464,6 +8658,7 @@ mod integration_tests {
                 let commitment = h.make_commitment(1);
                 h.client.continue_streak(&player, &commitment);
                 let secret = h.make_secret(1);
+                env.ledger().with_mut(|l| l.sequence_number += 1);
                 let won = h.client.reveal(&player, &secret);
                 assert!(won, "round {} must win", expected_streak);
             }
@@ -8539,6 +8734,7 @@ mod integration_tests {
         let player = h.player();
         h.fund(1_000_000_000);
         h.client.start_game(&player, &Side::Heads, &DEFAULT_WAGER, &h.make_commitment(1));
+        env.ledger().with_mut(|l| l.sequence_number += 1);
         let result = h.client.reveal(&player, &h.make_secret(1));
         assert!(result, "seed 1 + Heads must win");
         let game = h.game_state(&player);
@@ -8554,6 +8750,7 @@ mod integration_tests {
         h.fund(1_000_000_000);
         let reserve_before = h.stats().reserve_balance;
         h.client.start_game(&player, &Side::Heads, &DEFAULT_WAGER, &h.make_commitment(3));
+        env.ledger().with_mut(|l| l.sequence_number += 1);
         let result = h.client.reveal(&player, &h.make_secret(3));
         assert!(!result, "seed 3 + Heads must lose");
         // Game state must be gone.
@@ -8586,6 +8783,7 @@ mod integration_tests {
         h.fund(1_000_000_000);
         // Win to reach Revealed phase.
         h.client.start_game(&player, &Side::Heads, &DEFAULT_WAGER, &h.make_commitment(1));
+        env.ledger().with_mut(|l| l.sequence_number += 1);
         h.client.reveal(&player, &h.make_secret(1));
         assert_eq!(h.game_state(&player).phase, GamePhase::Revealed);
         // Second reveal must be rejected.
@@ -8609,6 +8807,7 @@ mod integration_tests {
         let player = h.player();
         h.fund(1_000_000_000);
         h.client.start_game(&player, &Side::Heads, &DEFAULT_WAGER, &h.make_commitment(3));
+        env.ledger().with_mut(|l| l.sequence_number += 1);
         h.client.reveal(&player, &h.make_secret(3)); // loss
         let result = h.client.try_start_game(
             &player, &Side::Heads, &DEFAULT_WAGER, &h.make_commitment(1),
@@ -8629,6 +8828,7 @@ mod integration_tests {
         let contract_random = h.game_state(&player).contract_random;
         let secret = h.make_secret(seed);
         let expected_side = generate_outcome(&h.env, &secret, &contract_random);
+        env.ledger().with_mut(|l| l.sequence_number += 1);
         let won = h.client.reveal(&player, &secret);
         assert_eq!(won, expected_side == Side::Heads,
             "reveal result must match generate_outcome prediction");
@@ -8723,6 +8923,7 @@ mod integration_tests {
         let commitment = h.make_commitment(1);
         h.client.start_game(&player, &predicted, &DEFAULT_WAGER, &commitment);
         let secret = h.make_secret(1);
+        env.ledger().with_mut(|l| l.sequence_number += 1);
         let won = h.client.reveal(&player, &secret);
         assert!(won, "probe_outcome prediction must match actual reveal outcome");
     }
@@ -9428,6 +9629,7 @@ mod state_transition_tests {
             let player = Address::generate(&env);
             st_inject(&env, &contract_id, &player, GamePhase::Committed, 0, wager);
             let secret = st_secret(&env, 1);
+            env.ledger().with_mut(|l| l.sequence_number += 1);
             if client.reveal(&player, &secret) {
                 let g = st_game(&env, &contract_id, &player);
                 prop_assert_eq!(g.phase, GamePhase::Revealed);
@@ -9444,6 +9646,7 @@ mod state_transition_tests {
             let player = Address::generate(&env);
             st_inject(&env, &contract_id, &player, GamePhase::Committed, 0, wager);
             let secret = st_secret(&env, 3);
+            env.ledger().with_mut(|l| l.sequence_number += 1);
             if !client.reveal(&player, &secret) {
                 prop_assert!(st_game(&env, &contract_id, &player).is_none(),
                     "game must be deleted after loss");
@@ -9615,6 +9818,7 @@ mod state_transition_tests {
             st_fund(&env, &contract_id, 1_000_000_000);
             let player = Address::generate(&env);
             st_inject(&env, &contract_id, &player, GamePhase::Committed, initial_streak, wager);
+            env.ledger().with_mut(|l| l.sequence_number += 1);
             if client.reveal(&player, &st_secret(&env, 1)) {
                 let g = st_game(&env, &contract_id, &player);
                 prop_assert!(g.streak > initial_streak,
@@ -10093,6 +10297,7 @@ mod stress_tests {
             let seed = if i % 2 == 0 { 1u8 } else { 3u8 };
             let commit = str_commit(&env, seed);
             client.start_game(&player, &Side::Heads, &5_000_000, &commit);
+            env.ledger().with_mut(|l| l.sequence_number += 1);
             let won = client.reveal(&player, &str_secret(&env, seed));
             if won { client.cash_out(&player); }
         }
@@ -10233,6 +10438,7 @@ mod game_history_tests {
         let player = Address::generate(&env);
         // seed 3 → Tails outcome → loss for Heads player
         client.start_game(&player, &Side::Heads, &10_000_000, &hist_commit(&env, 3));
+        env.ledger().with_mut(|l| l.sequence_number += 1);
         client.reveal(&player, &hist_secret(&env, 3));
 
         let history = hist_history(&env, &contract_id, &player);
@@ -10253,6 +10459,7 @@ mod game_history_tests {
         let player = Address::generate(&env);
         // seed 1 → Heads outcome → win for Heads player
         client.start_game(&player, &Side::Heads, &10_000_000, &hist_commit(&env, 1));
+        env.ledger().with_mut(|l| l.sequence_number += 1);
         client.reveal(&player, &hist_secret(&env, 1));
         let payout = client.cash_out(&player);
 
@@ -10274,11 +10481,13 @@ mod game_history_tests {
 
         // Game 1: win
         client.start_game(&player, &Side::Heads, &5_000_000, &hist_commit(&env, 1));
+        env.ledger().with_mut(|l| l.sequence_number += 1);
         client.reveal(&player, &hist_secret(&env, 1));
         client.cash_out(&player);
 
         // Game 2: loss
         client.start_game(&player, &Side::Heads, &3_000_000, &hist_commit(&env, 3));
+        env.ledger().with_mut(|l| l.sequence_number += 1);
         client.reveal(&player, &hist_secret(&env, 3));
 
         let history = hist_history(&env, &contract_id, &player);
@@ -10298,6 +10507,7 @@ mod game_history_tests {
 
         for _ in 0..101 {
             client.start_game(&player, &Side::Heads, &1_000_000, &hist_commit(&env, 3));
+            env.ledger().with_mut(|l| l.sequence_number += 1);
             client.reveal(&player, &hist_secret(&env, 3));
         }
 
@@ -10317,6 +10527,7 @@ mod game_history_tests {
         // Create 5 loss entries.
         for _ in 0..5 {
             client.start_game(&player, &Side::Heads, &1_000_000, &hist_commit(&env, 3));
+            env.ledger().with_mut(|l| l.sequence_number += 1);
             client.reveal(&player, &hist_secret(&env, 3));
         }
 
@@ -10351,6 +10562,7 @@ mod game_history_tests {
 
         for _ in 0..30 {
             client.start_game(&player, &Side::Heads, &1_000_000, &hist_commit(&env, 3));
+            env.ledger().with_mut(|l| l.sequence_number += 1);
             client.reveal(&player, &hist_secret(&env, 3));
         }
 
@@ -10367,6 +10579,7 @@ mod game_history_tests {
         hist_fund(&env, &contract_id, 1_000_000_000);
         let player = Address::generate(&env);
         client.start_game(&player, &Side::Heads, &5_000_000, &hist_commit(&env, 3));
+        env.ledger().with_mut(|l| l.sequence_number += 1);
         client.reveal(&player, &hist_secret(&env, 3));
 
         let result = client.verify_past_game(&player, &0);
@@ -10380,6 +10593,7 @@ mod game_history_tests {
         hist_fund(&env, &contract_id, 1_000_000_000);
         let player = Address::generate(&env);
         client.start_game(&player, &Side::Heads, &5_000_000, &hist_commit(&env, 1));
+        env.ledger().with_mut(|l| l.sequence_number += 1);
         client.reveal(&player, &hist_secret(&env, 1));
         client.cash_out(&player);
 
@@ -10404,6 +10618,7 @@ mod game_history_tests {
         hist_fund(&env, &contract_id, 1_000_000_000);
         let player = Address::generate(&env);
         client.start_game(&player, &Side::Heads, &5_000_000, &hist_commit(&env, 3));
+        env.ledger().with_mut(|l| l.sequence_number += 1);
         client.reveal(&player, &hist_secret(&env, 3));
 
         let result = client.try_verify_past_game(&player, &99);
@@ -10424,6 +10639,7 @@ mod game_history_tests {
         let contract_random = env.as_contract(&contract_id, || {
             CoinflipContract::load_player_game(&env, &player).unwrap().unwrap().contract_random
         });
+        env.ledger().with_mut(|l| l.sequence_number += 1);
         client.reveal(&player, &hist_secret(&env, 3));
 
         let entry = hist_history(&env, &contract_id, &player).get(0).unwrap();
@@ -10445,6 +10661,7 @@ mod game_history_tests {
             let player = Address::generate(&env);
             for _ in 0..n_games {
                 client.start_game(&player, &Side::Heads, &1_000_000, &hist_commit(&env, 3));
+                env.ledger().with_mut(|l| l.sequence_number += 1);
                 client.reveal(&player, &hist_secret(&env, 3));
             }
             let len = hist_history(&env, &contract_id, &player).len();
@@ -10462,6 +10679,7 @@ mod game_history_tests {
             let player = Address::generate(&env);
             for _ in 0..n_games {
                 client.start_game(&player, &Side::Heads, &1_000_000, &hist_commit(&env, 3));
+                env.ledger().with_mut(|l| l.sequence_number += 1);
                 client.reveal(&player, &hist_secret(&env, 3));
             }
             let result = client.get_game_history(&player, &offset, &10);
@@ -10476,6 +10694,7 @@ mod game_history_tests {
             let player = Address::generate(&env);
             for _ in 0..n_games {
                 client.start_game(&player, &Side::Heads, &1_000_000, &hist_commit(&env, 3));
+                env.ledger().with_mut(|l| l.sequence_number += 1);
                 client.reveal(&player, &hist_secret(&env, 3));
             }
             let history = hist_history(&env, &contract_id, &player);

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -666,6 +666,56 @@ pub fn verify_outcome_proof(env: &Env, proof: &OutcomeProof) -> bool {
     generate_outcome(env, &proof.secret, &proof.contract_random) == proof.outcome
 }
 
+/// A cryptographic audit trail for a single game's randomness generation.
+///
+/// Captures every step of the commit-reveal protocol so any observer can
+/// independently verify that the outcome was not manipulated by either party.
+///
+/// ## Verification steps (all reproducible with plain SHA-256)
+///
+/// 1. `SHA-256(secret) == commitment`
+///    — player was bound to their secret before `contract_random` was known
+/// 2. `SHA-256(ledger_sequence_bytes) == contract_random`
+///    — contract's contribution was fixed at game-start time
+/// 3. `SHA-256(secret || contract_random)[0] & 1` → outcome bit
+///    — neither party could unilaterally choose the result
+/// 4. `outcome == recorded_outcome`
+///    — the stored result matches the derivation
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RandomnessTrail {
+    /// Player's secret pre-image; reveals after game completion.
+    pub secret: Bytes,
+    /// SHA-256(secret); submitted before contract_random was known.
+    pub commitment: BytesN<32>,
+    /// SHA-256(ledger_sequence); fixed at game-start time.
+    pub contract_random: BytesN<32>,
+    /// Ledger sequence number at game creation; anchors contract_random.
+    pub ledger: u32,
+    /// Derived outcome: `SHA-256(secret || contract_random)[0] & 1`.
+    pub outcome: Side,
+    /// Whether the commitment → outcome chain verifies correctly.
+    pub valid: bool,
+}
+
+/// Verify the full randomness generation chain for a [`RandomnessTrail`].
+///
+/// Checks:
+/// 1. `SHA-256(trail.secret) == trail.commitment`
+/// 2. `generate_outcome(trail.secret, trail.contract_random) == trail.outcome`
+///
+/// Returns `false` immediately if `trail.secret` is empty (incomplete trail).
+/// This function is pure — no storage reads, no side effects.
+pub fn verify_randomness_trail(env: &Env, trail: &RandomnessTrail) -> bool {
+    if trail.secret.is_empty() {
+        return false;
+    }
+    if !verify_commitment(env, &trail.secret, &trail.commitment) {
+        return false;
+    }
+    generate_outcome(env, &trail.secret, &trail.contract_random) == trail.outcome
+}
+
 /// Provably fair coinflip game contract for the Stellar/Soroban platform.
 ///
 /// ## Public API
@@ -1730,6 +1780,48 @@ impl CoinflipContract {
             outcome: entry.outcome,
             side: entry.side,
             ledger: entry.ledger,
+        }))
+    }
+
+    /// Build a [`RandomnessTrail`] for a completed game in the player's history.
+    ///
+    /// Returns the full audit trail for the entry at `history_idx`, including
+    /// a pre-computed `valid` flag indicating whether the chain verifies.
+    /// Returns `None` when the entry's secret is empty (games settled via
+    /// `cash_out` do not re-store the secret after reveal).
+    ///
+    /// # Arguments
+    /// - `player`      – address whose history to inspect
+    /// - `history_idx` – index into the player's history buffer (0 = oldest)
+    ///
+    /// # Errors
+    /// - [`Error::NoActiveGame`] – no history exists for `player`
+    /// - [`Error::InvalidPhase`] – `history_idx` is out of range
+    pub fn get_randomness_trail(
+        env: Env,
+        player: Address,
+        history_idx: u32,
+    ) -> Result<Option<RandomnessTrail>, Error> {
+        let history = Self::load_player_history(&env, &player);
+        if history.is_empty() {
+            return Err(Error::NoActiveGame);
+        }
+        if history_idx >= history.len() {
+            return Err(Error::InvalidPhase);
+        }
+        let entry = history.get(history_idx).unwrap();
+        if entry.secret.is_empty() {
+            return Ok(None);
+        }
+        let valid = verify_commitment(&env, &entry.secret, &entry.commitment)
+            && generate_outcome(&env, &entry.secret, &entry.contract_random) == entry.outcome;
+        Ok(Some(RandomnessTrail {
+            secret: entry.secret,
+            commitment: entry.commitment,
+            contract_random: entry.contract_random,
+            outcome: entry.outcome,
+            ledger: entry.ledger,
+            valid,
         }))
     }
 
@@ -5828,6 +5920,229 @@ mod outcome_proof_property_tests {
 //   where fee_i = floor(gross_i * fee_bps_i / 10_000)
 //   and   gross_i = floor(wager_i * multiplier(streak_i) / 10_000)
 // ═══════════════════════════════════════════════════════════════════════════
+// Feature: randomness audit trail
+// Module:  randomness_audit_trail_tests
+// ═══════════════════════════════════════════════════════════════════════════
+#[cfg(test)]
+mod randomness_audit_trail_tests {
+    use super::*;
+    use proptest::prelude::*;
+    use soroban_sdk::testutils::Address as _;
+
+    fn setup(env: &Env) -> soroban_sdk::Address {
+        env.mock_all_auths();
+        let contract_id = env.register(CoinflipContract, ());
+        let client = CoinflipContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        let treasury = Address::generate(env);
+        let token = Address::generate(env);
+        client.initialize(&admin, &treasury, &token, &300, &1_000_000, &100_000_000);
+        contract_id
+    }
+
+    /// Inject a history entry with a known secret and return the expected trail.
+    fn inject_entry(env: &Env, contract_id: &soroban_sdk::Address, player: &Address, secret_bytes: &[u8]) -> RandomnessTrail {
+        let secret = Bytes::from_slice(env, secret_bytes);
+        let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
+        let contract_random: BytesN<32> = env.crypto().sha256(&Bytes::from_slice(env, &[55u8; 32])).into();
+        let outcome = generate_outcome(env, &secret, &contract_random);
+        env.as_contract(contract_id, || {
+            CoinflipContract::save_history_entry(env, player, HistoryEntry {
+                wager: 10_000_000, side: Side::Heads, outcome, won: outcome == Side::Heads,
+                streak: 1, commitment: commitment.clone(), secret: secret.clone(),
+                contract_random: contract_random.clone(), payout: 0, ledger: 42,
+            });
+        });
+        RandomnessTrail { secret, commitment, contract_random, outcome, ledger: 42, valid: true }
+    }
+
+    // ── verify_randomness_trail ──────────────────────────────────────────────
+
+    #[test]
+    fn test_valid_trail_verifies() {
+        let env = Env::default();
+        let secret = Bytes::from_slice(&env, &[3u8; 32]);
+        let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
+        let contract_random: BytesN<32> = env.crypto().sha256(&Bytes::from_slice(&env, &[7u8; 32])).into();
+        let outcome = generate_outcome(&env, &secret, &contract_random);
+        let trail = RandomnessTrail { secret, commitment, contract_random, outcome, ledger: 1, valid: false };
+        assert!(verify_randomness_trail(&env, &trail));
+    }
+
+    #[test]
+    fn test_empty_secret_fails() {
+        let env = Env::default();
+        let trail = RandomnessTrail {
+            secret: Bytes::new(&env),
+            commitment: BytesN::from_array(&env, &[0u8; 32]),
+            contract_random: BytesN::from_array(&env, &[0u8; 32]),
+            outcome: Side::Heads, ledger: 0, valid: false,
+        };
+        assert!(!verify_randomness_trail(&env, &trail));
+    }
+
+    #[test]
+    fn test_tampered_commitment_fails() {
+        let env = Env::default();
+        let secret = Bytes::from_slice(&env, &[3u8; 32]);
+        let contract_random: BytesN<32> = env.crypto().sha256(&Bytes::from_slice(&env, &[7u8; 32])).into();
+        let outcome = generate_outcome(&env, &secret, &contract_random);
+        let trail = RandomnessTrail {
+            secret,
+            commitment: BytesN::from_array(&env, &[0u8; 32]), // wrong
+            contract_random, outcome, ledger: 0, valid: false,
+        };
+        assert!(!verify_randomness_trail(&env, &trail));
+    }
+
+    #[test]
+    fn test_tampered_outcome_fails() {
+        let env = Env::default();
+        let secret = Bytes::from_slice(&env, &[3u8; 32]);
+        let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
+        let contract_random: BytesN<32> = env.crypto().sha256(&Bytes::from_slice(&env, &[7u8; 32])).into();
+        let real_outcome = generate_outcome(&env, &secret, &contract_random);
+        let flipped = match real_outcome { Side::Heads => Side::Tails, Side::Tails => Side::Heads };
+        let trail = RandomnessTrail { secret, commitment, contract_random, outcome: flipped, ledger: 0, valid: false };
+        assert!(!verify_randomness_trail(&env, &trail));
+    }
+
+    // ── get_randomness_trail ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_get_trail_returns_correct_data() {
+        let env = Env::default();
+        let contract_id = setup(&env);
+        let client = CoinflipContractClient::new(&env, &contract_id);
+        let player = Address::generate(&env);
+        let expected = inject_entry(&env, &contract_id, &player, &[3u8; 32]);
+
+        let trail = client.get_randomness_trail(&player, &0).unwrap().unwrap();
+        assert_eq!(trail.secret, expected.secret);
+        assert_eq!(trail.commitment, expected.commitment);
+        assert_eq!(trail.contract_random, expected.contract_random);
+        assert_eq!(trail.outcome, expected.outcome);
+        assert_eq!(trail.ledger, expected.ledger);
+        assert!(trail.valid);
+    }
+
+    #[test]
+    fn test_get_trail_valid_flag_is_true_for_honest_entry() {
+        let env = Env::default();
+        let contract_id = setup(&env);
+        let client = CoinflipContractClient::new(&env, &contract_id);
+        let player = Address::generate(&env);
+        inject_entry(&env, &contract_id, &player, &[3u8; 32]);
+        let trail = client.get_randomness_trail(&player, &0).unwrap().unwrap();
+        assert!(trail.valid);
+    }
+
+    #[test]
+    fn test_get_trail_no_history_returns_error() {
+        let env = Env::default();
+        let contract_id = setup(&env);
+        let client = CoinflipContractClient::new(&env, &contract_id);
+        let player = Address::generate(&env);
+        assert_eq!(client.try_get_randomness_trail(&player, &0), Err(Ok(Error::NoActiveGame)));
+    }
+
+    #[test]
+    fn test_get_trail_out_of_range_returns_error() {
+        let env = Env::default();
+        let contract_id = setup(&env);
+        let client = CoinflipContractClient::new(&env, &contract_id);
+        let player = Address::generate(&env);
+        inject_entry(&env, &contract_id, &player, &[3u8; 32]);
+        assert_eq!(client.try_get_randomness_trail(&player, &99), Err(Ok(Error::InvalidPhase)));
+    }
+
+    #[test]
+    fn test_get_trail_empty_secret_returns_none() {
+        let env = Env::default();
+        let contract_id = setup(&env);
+        let client = CoinflipContractClient::new(&env, &contract_id);
+        let player = Address::generate(&env);
+        let commitment: BytesN<32> = env.crypto().sha256(&Bytes::from_slice(&env, &[1u8; 32])).into();
+        let contract_random: BytesN<32> = env.crypto().sha256(&Bytes::from_slice(&env, &[2u8; 32])).into();
+        env.as_contract(&contract_id, || {
+            CoinflipContract::save_history_entry(&env, &player, HistoryEntry {
+                wager: 0, side: Side::Heads, outcome: Side::Heads, won: true,
+                streak: 1, commitment, secret: Bytes::new(&env), // empty
+                contract_random, payout: 0, ledger: 1,
+            });
+        });
+        assert_eq!(client.get_randomness_trail(&player, &0), None);
+    }
+
+    #[test]
+    fn test_multiple_entries_indexed_correctly() {
+        let env = Env::default();
+        let contract_id = setup(&env);
+        let client = CoinflipContractClient::new(&env, &contract_id);
+        let player = Address::generate(&env);
+        inject_entry(&env, &contract_id, &player, &[1u8; 32]);
+        inject_entry(&env, &contract_id, &player, &[2u8; 32]);
+
+        let t0 = client.get_randomness_trail(&player, &0).unwrap().unwrap();
+        let t1 = client.get_randomness_trail(&player, &1).unwrap().unwrap();
+        assert_ne!(t0.secret, t1.secret);
+        assert!(t0.valid);
+        assert!(t1.valid);
+    }
+
+    // ── property tests ───────────────────────────────────────────────────────
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(200))]
+
+        /// Any trail built from a valid (secret, contract_random) pair must verify.
+        #[test]
+        fn prop_valid_trail_always_verifies(
+            secret_bytes   in prop::array::uniform32(1u8..=255u8),
+            contract_bytes in prop::array::uniform32(any::<u8>()),
+        ) {
+            let env = soroban_sdk::Env::default();
+            let secret = Bytes::from_slice(&env, &secret_bytes);
+            let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
+            let contract_random: BytesN<32> = BytesN::from_array(&env, &contract_bytes);
+            let outcome = generate_outcome(&env, &secret, &contract_random);
+            let trail = RandomnessTrail { secret, commitment, contract_random, outcome, ledger: 0, valid: false };
+            prop_assert!(verify_randomness_trail(&env, &trail));
+        }
+
+        /// Flipping the outcome always causes verification to fail.
+        #[test]
+        fn prop_tampered_outcome_always_fails(
+            secret_bytes   in prop::array::uniform32(1u8..=255u8),
+            contract_bytes in prop::array::uniform32(any::<u8>()),
+        ) {
+            let env = soroban_sdk::Env::default();
+            let secret = Bytes::from_slice(&env, &secret_bytes);
+            let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
+            let contract_random: BytesN<32> = BytesN::from_array(&env, &contract_bytes);
+            let real = generate_outcome(&env, &secret, &contract_random);
+            let flipped = match real { Side::Heads => Side::Tails, Side::Tails => Side::Heads };
+            let trail = RandomnessTrail { secret, commitment, contract_random, outcome: flipped, ledger: 0, valid: false };
+            prop_assert!(!verify_randomness_trail(&env, &trail));
+        }
+
+        /// verify_randomness_trail is deterministic.
+        #[test]
+        fn prop_verification_is_deterministic(
+            secret_bytes   in prop::array::uniform32(1u8..=255u8),
+            contract_bytes in prop::array::uniform32(any::<u8>()),
+        ) {
+            let env = soroban_sdk::Env::default();
+            let secret = Bytes::from_slice(&env, &secret_bytes);
+            let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
+            let contract_random: BytesN<32> = BytesN::from_array(&env, &contract_bytes);
+            let outcome = generate_outcome(&env, &secret, &contract_random);
+            let trail = RandomnessTrail { secret, commitment, contract_random, outcome, ledger: 0, valid: false };
+            prop_assert_eq!(verify_randomness_trail(&env, &trail), verify_randomness_trail(&env, &trail));
+        }
+    }
+}
+
 // Feature: secure key derivation / commitment strength
 // Module:  commitment_strength_tests
 // ═══════════════════════════════════════════════════════════════════════════

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -534,6 +534,72 @@ pub fn generate_outcome(env: &Env, player_secret: &Bytes, contract_random: &Byte
     if hash.to_array()[0] % 2 == 0 { Side::Heads } else { Side::Tails }
 }
 
+/// A self-contained proof bundle that lets any party verify a game outcome
+/// without trusting the contract or any third party.
+///
+/// ## What this proves
+///
+/// Given `(secret, commitment, contract_random, outcome)`, any verifier can
+/// independently confirm:
+///
+/// 1. **Commitment integrity** – `SHA-256(secret) == commitment`
+///    The player locked their secret before the contract's randomness was known.
+///
+/// 2. **Outcome correctness** – `SHA-256(secret || contract_random)[0] & 1`
+///    determines the outcome bit; the recorded `outcome` matches.
+///
+/// Together these two checks prove that neither party could have unilaterally
+/// chosen the outcome: the player was bound by their commitment, and the
+/// contract's randomness was fixed at game-start time.
+///
+/// ## Privacy note
+///
+/// This is a *transparent* proof — the secret is included in plain text.
+/// The privacy guarantee comes from the commit-reveal protocol itself:
+/// the secret is only revealed *after* the outcome is already determined,
+/// so revealing it post-game leaks no exploitable information.
+///
+/// Off-chain verifiers can reproduce both checks using only standard SHA-256,
+/// with no dependency on the contract or the Stellar network.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OutcomeProof {
+    /// The player's revealed secret (pre-image of `commitment`).
+    pub secret: Bytes,
+    /// SHA-256 of `secret`; submitted before `contract_random` was known.
+    pub commitment: BytesN<32>,
+    /// SHA-256 of the ledger sequence at game-start time.
+    pub contract_random: BytesN<32>,
+    /// The derived outcome: `SHA-256(secret || contract_random)[0] & 1 == 0 → Heads`.
+    pub outcome: Side,
+    /// The player's chosen side; `won == (outcome == side)`.
+    pub side: Side,
+    /// Ledger sequence at game creation; anchors the proof to a specific block.
+    pub ledger: u32,
+}
+
+/// Verify an [`OutcomeProof`] without any on-chain state.
+///
+/// Performs both checks that constitute a complete outcome proof:
+///
+/// 1. `SHA-256(proof.secret) == proof.commitment`
+/// 2. `generate_outcome(proof.secret, proof.contract_random) == proof.outcome`
+///
+/// Returns `true` only when both checks pass.  Returns `false` if either
+/// check fails or if `proof.secret` is empty (proof is incomplete).
+///
+/// This function is pure — it reads no storage and has no side effects.
+/// It can be called by anyone, on-chain or off-chain, to audit any game.
+pub fn verify_outcome_proof(env: &Env, proof: &OutcomeProof) -> bool {
+    if proof.secret.is_empty() {
+        return false;
+    }
+    if !verify_commitment(env, &proof.secret, &proof.commitment) {
+        return false;
+    }
+    generate_outcome(env, &proof.secret, &proof.contract_random) == proof.outcome
+}
+
 /// Provably fair coinflip game contract for the Stellar/Soroban platform.
 ///
 /// ## Public API
@@ -1544,6 +1610,48 @@ impl CoinflipContract {
             result.push_back(history.get(i).unwrap());
         }
         result
+    }
+
+    /// Build an [`OutcomeProof`] for a completed game in the player's history.
+    ///
+    /// Returns the proof bundle for the entry at `history_idx`.  The proof
+    /// can be passed to [`verify_outcome_proof`] (or verified off-chain with
+    /// plain SHA-256) to confirm the outcome without trusting the contract.
+    ///
+    /// Returns `None` when the entry's secret is empty (games settled via
+    /// `cash_out` do not re-store the secret after reveal).
+    ///
+    /// # Arguments
+    /// - `player`      – address whose history to inspect
+    /// - `history_idx` – index into the player's history buffer (0 = oldest)
+    ///
+    /// # Errors
+    /// - [`Error::NoActiveGame`] – no history exists for `player`
+    /// - [`Error::InvalidPhase`] – `history_idx` is out of range
+    pub fn get_outcome_proof(
+        env: Env,
+        player: Address,
+        history_idx: u32,
+    ) -> Result<Option<OutcomeProof>, Error> {
+        let history = Self::load_player_history(&env, &player);
+        if history.is_empty() {
+            return Err(Error::NoActiveGame);
+        }
+        if history_idx >= history.len() {
+            return Err(Error::InvalidPhase);
+        }
+        let entry = history.get(history_idx).unwrap();
+        if entry.secret.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(OutcomeProof {
+            secret: entry.secret,
+            commitment: entry.commitment,
+            contract_random: entry.contract_random,
+            outcome: entry.outcome,
+            side: entry.side,
+            ledger: entry.ledger,
+        }))
     }
 
     /// Verify that a past game's outcome is reproducible from its stored proof.
@@ -5298,8 +5406,337 @@ mod property_tests {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Feature: soroban-coinflip-game
-// Module:  cumulative_fee_tests
+// Feature: outcome proof verification
+// Module:  outcome_proof_tests
+//
+// Validates OutcomeProof generation, verify_outcome_proof correctness, and
+// tamper-detection across all proof fields.
+// ═══════════════════════════════════════════════════════════════════════════
+#[cfg(test)]
+mod outcome_proof_tests {
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+
+    fn make_proof(env: &Env, secret_bytes: &[u8], side: Side) -> OutcomeProof {
+        let secret: Bytes = Bytes::from_slice(env, secret_bytes);
+        let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
+        let contract_random: BytesN<32> = env
+            .crypto()
+            .sha256(&Bytes::from_slice(env, &[99u8; 32]))
+            .into();
+        let outcome = generate_outcome(env, &secret, &contract_random);
+        OutcomeProof { secret, commitment, contract_random, outcome, side, ledger: 1 }
+    }
+
+    // ── verify_outcome_proof ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_valid_proof_verifies() {
+        let env = Env::default();
+        let proof = make_proof(&env, &[1u8; 32], Side::Heads);
+        assert!(verify_outcome_proof(&env, &proof));
+    }
+
+    #[test]
+    fn test_empty_secret_fails() {
+        let env = Env::default();
+        let mut proof = make_proof(&env, &[1u8; 32], Side::Heads);
+        proof.secret = Bytes::new(&env);
+        assert!(!verify_outcome_proof(&env, &proof));
+    }
+
+    #[test]
+    fn test_tampered_secret_fails() {
+        let env = Env::default();
+        let mut proof = make_proof(&env, &[1u8; 32], Side::Heads);
+        proof.secret = Bytes::from_slice(&env, &[2u8; 32]); // wrong secret
+        assert!(!verify_outcome_proof(&env, &proof));
+    }
+
+    #[test]
+    fn test_tampered_commitment_fails() {
+        let env = Env::default();
+        let mut proof = make_proof(&env, &[1u8; 32], Side::Heads);
+        proof.commitment = BytesN::from_array(&env, &[0u8; 32]); // wrong commitment
+        assert!(!verify_outcome_proof(&env, &proof));
+    }
+
+    #[test]
+    fn test_tampered_outcome_fails() {
+        let env = Env::default();
+        let mut proof = make_proof(&env, &[1u8; 32], Side::Heads);
+        // Flip the outcome to the opposite side
+        proof.outcome = match proof.outcome {
+            Side::Heads => Side::Tails,
+            Side::Tails => Side::Heads,
+        };
+        assert!(!verify_outcome_proof(&env, &proof));
+    }
+
+    #[test]
+    fn test_tampered_contract_random_fails() {
+        let env = Env::default();
+        let mut proof = make_proof(&env, &[1u8; 32], Side::Heads);
+        proof.contract_random = BytesN::from_array(&env, &[0u8; 32]); // wrong random
+        // outcome was derived from the original contract_random, so re-derivation
+        // with the tampered value will produce a different (or same) side — but
+        // the commitment check still passes; the outcome check may fail.
+        // We verify that the proof is no longer fully valid.
+        let recomputed = generate_outcome(&env, &proof.secret, &proof.contract_random);
+        // The proof is invalid if the recomputed outcome differs from the stored one.
+        // (If by coincidence they match, the proof would still pass — that's fine,
+        //  it just means the tampered random happened to produce the same bit.)
+        let expected = recomputed == proof.outcome;
+        assert_eq!(verify_outcome_proof(&env, &proof), expected);
+    }
+
+    // ── get_outcome_proof ────────────────────────────────────────────────────
+
+    /// Set up contract and return (env, contract_id).
+    fn setup_contract(env: &Env) -> soroban_sdk::Address {
+        env.mock_all_auths();
+        let contract_id = env.register(CoinflipContract, ());
+        let client = CoinflipContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        let treasury = Address::generate(env);
+        let token = Address::generate(env);
+        client.initialize(&admin, &treasury, &token, &300, &1_000_000, &100_000_000);
+        env.as_contract(&contract_id, || {
+            let mut stats = CoinflipContract::load_stats(env);
+            stats.reserve_balance = i128::MAX / 2;
+            CoinflipContract::save_stats(env, &stats);
+        });
+        contract_id
+    }
+
+    /// Inject a completed history entry with a known secret.
+    fn inject_history(env: &Env, contract_id: &soroban_sdk::Address, player: &Address, secret_bytes: &[u8]) -> OutcomeProof {
+        let secret = Bytes::from_slice(env, secret_bytes);
+        let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
+        let contract_random: BytesN<32> = env
+            .crypto()
+            .sha256(&Bytes::from_slice(env, &[77u8; 32]))
+            .into();
+        let outcome = generate_outcome(env, &secret, &contract_random);
+        let entry = HistoryEntry {
+            wager: 10_000_000,
+            side: Side::Heads,
+            outcome,
+            won: outcome == Side::Heads,
+            streak: 1,
+            commitment: commitment.clone(),
+            secret: secret.clone(),
+            contract_random: contract_random.clone(),
+            payout: 18_430_000,
+            ledger: 42,
+        };
+        env.as_contract(contract_id, || {
+            CoinflipContract::save_history_entry(env, player, entry);
+        });
+        OutcomeProof { secret, commitment, contract_random, outcome, side: Side::Heads, ledger: 42 }
+    }
+
+    #[test]
+    fn test_get_outcome_proof_returns_correct_proof() {
+        let env = Env::default();
+        let contract_id = setup_contract(&env);
+        let client = CoinflipContractClient::new(&env, &contract_id);
+        let player = Address::generate(&env);
+
+        let expected = inject_history(&env, &contract_id, &player, &[5u8; 32]);
+        let proof = client.get_outcome_proof(&player, &0).unwrap();
+
+        assert_eq!(proof.secret, expected.secret);
+        assert_eq!(proof.commitment, expected.commitment);
+        assert_eq!(proof.contract_random, expected.contract_random);
+        assert_eq!(proof.outcome, expected.outcome);
+        assert_eq!(proof.ledger, expected.ledger);
+    }
+
+    #[test]
+    fn test_get_outcome_proof_verifies() {
+        let env = Env::default();
+        let contract_id = setup_contract(&env);
+        let client = CoinflipContractClient::new(&env, &contract_id);
+        let player = Address::generate(&env);
+
+        inject_history(&env, &contract_id, &player, &[5u8; 32]);
+        let proof = client.get_outcome_proof(&player, &0).unwrap().unwrap();
+
+        // The returned proof must pass verify_outcome_proof.
+        assert!(verify_outcome_proof(&env, &proof));
+    }
+
+    #[test]
+    fn test_get_outcome_proof_no_history_returns_error() {
+        let env = Env::default();
+        let contract_id = setup_contract(&env);
+        let client = CoinflipContractClient::new(&env, &contract_id);
+        let player = Address::generate(&env);
+
+        let result = client.try_get_outcome_proof(&player, &0);
+        assert_eq!(result, Err(Ok(Error::NoActiveGame)));
+    }
+
+    #[test]
+    fn test_get_outcome_proof_out_of_range_returns_error() {
+        let env = Env::default();
+        let contract_id = setup_contract(&env);
+        let client = CoinflipContractClient::new(&env, &contract_id);
+        let player = Address::generate(&env);
+
+        inject_history(&env, &contract_id, &player, &[5u8; 32]);
+        let result = client.try_get_outcome_proof(&player, &99);
+        assert_eq!(result, Err(Ok(Error::InvalidPhase)));
+    }
+
+    #[test]
+    fn test_get_outcome_proof_empty_secret_returns_none() {
+        let env = Env::default();
+        let contract_id = setup_contract(&env);
+        let client = CoinflipContractClient::new(&env, &contract_id);
+        let player = Address::generate(&env);
+
+        // Inject a history entry with an empty secret (cash_out path).
+        let commitment: BytesN<32> = env
+            .crypto()
+            .sha256(&Bytes::from_slice(&env, &[1u8; 32]))
+            .into();
+        let contract_random: BytesN<32> = env
+            .crypto()
+            .sha256(&Bytes::from_slice(&env, &[2u8; 32]))
+            .into();
+        let entry = HistoryEntry {
+            wager: 10_000_000,
+            side: Side::Heads,
+            outcome: Side::Heads,
+            won: true,
+            streak: 1,
+            commitment,
+            secret: Bytes::new(&env), // empty — cash_out path
+            contract_random,
+            payout: 18_430_000,
+            ledger: 1,
+        };
+        env.as_contract(&contract_id, || {
+            CoinflipContract::save_history_entry(&env, &player, entry);
+        });
+
+        let result = client.get_outcome_proof(&player, &0);
+        assert_eq!(result, None);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Feature: outcome proof verification (property tests)
+// ═══════════════════════════════════════════════════════════════════════════
+#[cfg(test)]
+mod outcome_proof_property_tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(200))]
+
+        /// Any proof built from a valid (secret, contract_random) pair must verify.
+        #[test]
+        fn prop_valid_proof_always_verifies(
+            secret_bytes   in prop::array::uniform32(1u8..=255u8),
+            contract_bytes in prop::array::uniform32(any::<u8>()),
+        ) {
+            let env = soroban_sdk::Env::default();
+            let secret: Bytes = Bytes::from_slice(&env, &secret_bytes);
+            let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
+            let contract_random: BytesN<32> = BytesN::from_array(&env, &contract_bytes);
+            let outcome = generate_outcome(&env, &secret, &contract_random);
+            let proof = OutcomeProof {
+                secret, commitment, contract_random, outcome,
+                side: Side::Heads, ledger: 0,
+            };
+            prop_assert!(verify_outcome_proof(&env, &proof));
+        }
+
+        /// Flipping the outcome field always causes verification to fail.
+        #[test]
+        fn prop_tampered_outcome_always_fails(
+            secret_bytes   in prop::array::uniform32(1u8..=255u8),
+            contract_bytes in prop::array::uniform32(any::<u8>()),
+        ) {
+            let env = soroban_sdk::Env::default();
+            let secret: Bytes = Bytes::from_slice(&env, &secret_bytes);
+            let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
+            let contract_random: BytesN<32> = BytesN::from_array(&env, &contract_bytes);
+            let real_outcome = generate_outcome(&env, &secret, &contract_random);
+            let flipped = match real_outcome { Side::Heads => Side::Tails, Side::Tails => Side::Heads };
+            let proof = OutcomeProof {
+                secret, commitment, contract_random, outcome: flipped,
+                side: Side::Heads, ledger: 0,
+            };
+            prop_assert!(!verify_outcome_proof(&env, &proof));
+        }
+
+        /// A wrong secret (different from the one that produced the commitment)
+        /// always causes verification to fail.
+        #[test]
+        fn prop_wrong_secret_always_fails(
+            real_bytes  in prop::array::uniform32(1u8..=255u8),
+            wrong_bytes in prop::array::uniform32(1u8..=255u8),
+            contract_bytes in prop::array::uniform32(any::<u8>()),
+        ) {
+            prop_assume!(real_bytes != wrong_bytes);
+            let env = soroban_sdk::Env::default();
+            let real_secret: Bytes = Bytes::from_slice(&env, &real_bytes);
+            let wrong_secret: Bytes = Bytes::from_slice(&env, &wrong_bytes);
+            let commitment: BytesN<32> = env.crypto().sha256(&real_secret).into();
+            let contract_random: BytesN<32> = BytesN::from_array(&env, &contract_bytes);
+            let outcome = generate_outcome(&env, &real_secret, &contract_random);
+            let proof = OutcomeProof {
+                secret: wrong_secret, commitment, contract_random, outcome,
+                side: Side::Heads, ledger: 0,
+            };
+            prop_assert!(!verify_outcome_proof(&env, &proof));
+        }
+
+        /// An empty secret always causes verification to fail.
+        #[test]
+        fn prop_empty_secret_always_fails(
+            contract_bytes in prop::array::uniform32(any::<u8>()),
+        ) {
+            let env = soroban_sdk::Env::default();
+            let contract_random: BytesN<32> = BytesN::from_array(&env, &contract_bytes);
+            let proof = OutcomeProof {
+                secret: Bytes::new(&env),
+                commitment: BytesN::from_array(&env, &[0u8; 32]),
+                contract_random,
+                outcome: Side::Heads,
+                side: Side::Heads,
+                ledger: 0,
+            };
+            prop_assert!(!verify_outcome_proof(&env, &proof));
+        }
+
+        /// verify_outcome_proof is deterministic: same proof → same result.
+        #[test]
+        fn prop_verification_is_deterministic(
+            secret_bytes   in prop::array::uniform32(1u8..=255u8),
+            contract_bytes in prop::array::uniform32(any::<u8>()),
+        ) {
+            let env = soroban_sdk::Env::default();
+            let secret: Bytes = Bytes::from_slice(&env, &secret_bytes);
+            let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
+            let contract_random: BytesN<32> = BytesN::from_array(&env, &contract_bytes);
+            let outcome = generate_outcome(&env, &secret, &contract_random);
+            let proof = OutcomeProof {
+                secret, commitment, contract_random, outcome,
+                side: Side::Heads, ledger: 0,
+            };
+            prop_assert_eq!(
+                verify_outcome_proof(&env, &proof),
+                verify_outcome_proof(&env, &proof)
+            );
+        }
+    }
+}
 //
 // Verifies that `total_fees` in ContractStats accumulates correctly across
 // multiple sequential payouts and across fee_bps configuration changes.

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -52,6 +52,7 @@ use soroban_sdk::{contract, contractimpl, contracttype, contracterror, token, Ad
 /// | 13   | `RevealTimeout`              | Reveal         | (reserved for future timeout enforcement) |
 /// | 20   | `NoWinningsToClaimOrContinue`| Action         | `cash_out`, `claim_winnings`, `continue_streak` |
 /// | 21   | `InvalidCommitment`          | Action         | `continue_streak`                  |
+/// | 22   | `WeakCommitment`             | Action         | `start_game`, `continue_streak`    |
 /// | 30   | `Unauthorized`               | Admin          | `set_paused`, `set_treasury`, `set_wager_limits`, `set_fee` |
 /// | 31   | `InvalidFeePercentage`       | Admin          | `initialize`, `set_fee`            |
 /// | 32   | `InvalidWagerLimits`         | Admin          | `initialize`, `set_wager_limits`   |
@@ -72,9 +73,11 @@ pub mod error_codes {
     pub const COMMITMENT_MISMATCH: u32 = 12;
     pub const REVEAL_TIMEOUT: u32 = 13;
 
-    // Action errors (20–21)
+    // Action errors (20–22)
     pub const NO_WINNINGS_TO_CLAIM_OR_CONTINUE: u32 = 20;
     pub const INVALID_COMMITMENT: u32 = 21;
+    /// Commitment has insufficient entropy (all-same-byte or trivially weak pattern).
+    pub const WEAK_COMMITMENT: u32 = 22;
 
     // Admin errors (30–32)
     pub const UNAUTHORIZED: u32 = 30;
@@ -89,7 +92,7 @@ pub mod error_codes {
     pub const ALREADY_INITIALIZED: u32 = 51;
 
     /// Total number of defined error variants.
-    pub const VARIANT_COUNT: usize = 17;
+    pub const VARIANT_COUNT: usize = 18;
 }
 
 /// Error codes for the coinflip contract.
@@ -170,6 +173,13 @@ pub enum Error {
     /// Returned by: `continue_streak` (guard 4).
     /// Code: 21 — see [`error_codes::INVALID_COMMITMENT`]
     InvalidCommitment = 21,
+
+    /// Commitment has insufficient entropy (all-same-byte pattern).
+    /// A commitment where every byte is identical provides no randomness and
+    /// would allow a player to predict or bias outcomes.
+    /// Returned by: `start_game`, `continue_streak`.
+    /// Code: 22 — see [`error_codes::WEAK_COMMITMENT`]
+    WeakCommitment = 22,
 
     // ── Admin errors (30–32) ────────────────────────────────────────────────
 
@@ -496,6 +506,62 @@ pub fn calculate_payout(wager: i128, streak: u32, fee_bps: u32) -> Option<i128> 
 pub fn verify_commitment(env: &Env, secret: &Bytes, commitment: &BytesN<32>) -> bool {
     let hash: BytesN<32> = env.crypto().sha256(secret).into();
     &hash == commitment
+}
+
+/// Validates that a commitment has sufficient entropy to be secure.
+///
+/// A commitment is considered weak when all 32 bytes are identical — this
+/// pattern indicates a placeholder, a zeroed buffer, or a trivially
+/// constructed value that provides no randomness.  Such commitments could
+/// allow a player to predict or bias outcomes.
+///
+/// Returns `true` when the commitment passes the strength check (safe to use).
+/// Returns `false` when all bytes are the same (weak/placeholder).
+///
+/// ## Entropy requirement
+///
+/// A valid commitment must be the SHA-256 output of a secret with at least
+/// 128 bits of entropy.  SHA-256 produces 256-bit outputs; any output where
+/// all bytes are identical has probability 2^-248 under a uniform distribution,
+/// making it a reliable indicator of a non-random input.
+pub fn validate_commitment_strength(commitment: &BytesN<32>) -> bool {
+    let arr = commitment.to_array();
+    let first = arr[0];
+    // Reject if every byte equals the first byte (all-same pattern).
+    arr.iter().all(|&b| b == first) == false
+}
+
+/// Derives a commitment from a player secret using SHA-256 with domain separation.
+///
+/// ## Usage
+///
+/// Players should call this off-chain to generate their commitment before
+/// calling `start_game` or `continue_streak`.  The returned value is the
+/// commitment to submit on-chain; the `secret` must be kept private until
+/// the reveal step.
+///
+/// ## Domain separation
+///
+/// A fixed domain prefix `b"tossd:commitment:v1:"` is prepended to the secret
+/// before hashing.  This prevents cross-protocol hash collisions: a SHA-256
+/// output computed for a different purpose cannot be replayed as a valid
+/// Tossd commitment.
+///
+/// ## Security
+///
+/// The secret must have at least 128 bits of entropy (e.g. 16+ random bytes).
+/// Using a low-entropy secret (a short password, a counter, etc.) weakens the
+/// commit-reveal guarantee even though the hash itself is cryptographically
+/// sound.
+///
+/// # Arguments
+/// - `env`    – Soroban execution environment (needed for SHA-256)
+/// - `secret` – raw secret bytes; must be kept private until reveal
+pub fn derive_commitment(env: &Env, secret: &Bytes) -> BytesN<32> {
+    const DOMAIN: &[u8] = b"tossd:commitment:v1:";
+    let mut input = Bytes::from_slice(env, DOMAIN);
+    input.append(secret);
+    env.crypto().sha256(&input).into()
 }
 
 /// Deterministically derives a [`Side`] outcome from the player's revealed secret
@@ -870,7 +936,15 @@ impl CoinflipContract {
             }
         }
 
-        // Guard 5: reserves must cover the worst-case payout (streak 4+, no fee deduction)
+        // Guard 5: commitment must not be all-zero (placeholder) or all-same-byte (weak)
+        if commitment == BytesN::from_array(&env, &[0u8; 32]) {
+            return Err(Error::InvalidCommitment);
+        }
+        if !validate_commitment_strength(&commitment) {
+            return Err(Error::WeakCommitment);
+        }
+
+        // Guard 6: reserves must cover the worst-case payout (streak 4+, no fee deduction)
         let stats = Self::load_stats(&env);
         let max_payout = wager
             .checked_mul(MULTIPLIER_STREAK_4_PLUS as i128)
@@ -1277,6 +1351,11 @@ impl CoinflipContract {
         // Guard 4: commitment must not be all-zero bytes (missing / placeholder)
         if new_commitment == BytesN::from_array(&env, &[0u8; 32]) {
             return Err(Error::InvalidCommitment);
+        }
+
+        // Guard 4b: commitment must not be all-same-byte (weak / low-entropy)
+        if !validate_commitment_strength(&new_commitment) {
+            return Err(Error::WeakCommitment);
         }
 
         // Guard 5: reserves must cover the next streak's worst-case payout.
@@ -1874,6 +1953,7 @@ mod tests {
         assert_eq!(Error::RevealTimeout as u32, 13);
         assert_eq!(Error::NoWinningsToClaimOrContinue as u32, 20);
         assert_eq!(Error::InvalidCommitment as u32, 21);
+        assert_eq!(Error::WeakCommitment as u32, 22);
         assert_eq!(Error::Unauthorized as u32, 30);
         assert_eq!(Error::InvalidFeePercentage as u32, 31);
         assert_eq!(Error::InvalidWagerLimits as u32, 32);
@@ -5241,6 +5321,7 @@ mod property_tests {
             prop_assert_eq!(Error::RevealTimeout as u32, error_codes::REVEAL_TIMEOUT);
             prop_assert_eq!(Error::NoWinningsToClaimOrContinue as u32, error_codes::NO_WINNINGS_TO_CLAIM_OR_CONTINUE);
             prop_assert_eq!(Error::InvalidCommitment as u32, error_codes::INVALID_COMMITMENT);
+            prop_assert_eq!(Error::WeakCommitment as u32, error_codes::WEAK_COMMITMENT);
             prop_assert_eq!(Error::Unauthorized as u32, error_codes::UNAUTHORIZED);
             prop_assert_eq!(Error::InvalidFeePercentage as u32, error_codes::INVALID_FEE_PERCENTAGE);
             prop_assert_eq!(Error::InvalidWagerLimits as u32, error_codes::INVALID_WAGER_LIMITS);
@@ -5252,9 +5333,9 @@ mod property_tests {
         /// VARIANT_COUNT must exactly match the number of Error enum variants.
         #[test]
         fn prop_variant_count_is_accurate(_dummy in 0u32..100u32) {
-            // All 17 variants enumerated — if a new variant is added without
+            // All 18 variants enumerated — if a new variant is added without
             // updating VARIANT_COUNT, this list will need to grow.
-            let all_codes: [u32; 17] = [
+            let all_codes: [u32; 18] = [
                 error_codes::WAGER_BELOW_MINIMUM,
                 error_codes::WAGER_ABOVE_MAXIMUM,
                 error_codes::ACTIVE_GAME_EXISTS,
@@ -5266,6 +5347,7 @@ mod property_tests {
                 error_codes::REVEAL_TIMEOUT,
                 error_codes::NO_WINNINGS_TO_CLAIM_OR_CONTINUE,
                 error_codes::INVALID_COMMITMENT,
+                error_codes::WEAK_COMMITMENT,
                 error_codes::UNAUTHORIZED,
                 error_codes::INVALID_FEE_PERCENTAGE,
                 error_codes::INVALID_WAGER_LIMITS,
@@ -5745,6 +5827,215 @@ mod outcome_proof_property_tests {
 //   total_fees_after == total_fees_before + Σ fee_i
 //   where fee_i = floor(gross_i * fee_bps_i / 10_000)
 //   and   gross_i = floor(wager_i * multiplier(streak_i) / 10_000)
+// ═══════════════════════════════════════════════════════════════════════════
+// Feature: secure key derivation / commitment strength
+// Module:  commitment_strength_tests
+// ═══════════════════════════════════════════════════════════════════════════
+#[cfg(test)]
+mod commitment_strength_tests {
+    use super::*;
+    use proptest::prelude::*;
+    use soroban_sdk::testutils::Address as _;
+
+    // ── validate_commitment_strength ─────────────────────────────────────────
+
+    #[test]
+    fn test_all_zero_is_weak() {
+        assert!(!validate_commitment_strength(&BytesN::from_array(&Env::default(), &[0u8; 32])));
+    }
+
+    #[test]
+    fn test_all_same_byte_is_weak() {
+        let env = Env::default();
+        for b in [1u8, 0xffu8, 0x42u8] {
+            assert!(!validate_commitment_strength(&BytesN::from_array(&env, &[b; 32])));
+        }
+    }
+
+    #[test]
+    fn test_sha256_output_is_strong() {
+        let env = Env::default();
+        let secret = Bytes::from_slice(&env, &[1u8; 32]);
+        let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
+        assert!(validate_commitment_strength(&commitment));
+    }
+
+    #[test]
+    fn test_mixed_bytes_is_strong() {
+        let env = Env::default();
+        let mut arr = [0u8; 32];
+        arr[0] = 1;
+        assert!(validate_commitment_strength(&BytesN::from_array(&env, &arr)));
+    }
+
+    // ── derive_commitment ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_derive_commitment_is_deterministic() {
+        let env = Env::default();
+        let secret = Bytes::from_slice(&env, &[7u8; 32]);
+        assert_eq!(derive_commitment(&env, &secret), derive_commitment(&env, &secret));
+    }
+
+    #[test]
+    fn test_derive_commitment_differs_from_plain_sha256() {
+        let env = Env::default();
+        let secret = Bytes::from_slice(&env, &[7u8; 32]);
+        let plain: BytesN<32> = env.crypto().sha256(&secret).into();
+        assert_ne!(derive_commitment(&env, &secret), plain);
+    }
+
+    #[test]
+    fn test_derive_commitment_output_is_strong() {
+        let env = Env::default();
+        let secret = Bytes::from_slice(&env, &[7u8; 32]);
+        assert!(validate_commitment_strength(&derive_commitment(&env, &secret)));
+    }
+
+    #[test]
+    fn test_derive_commitment_different_secrets_differ() {
+        let env = Env::default();
+        let s1 = Bytes::from_slice(&env, &[1u8; 32]);
+        let s2 = Bytes::from_slice(&env, &[2u8; 32]);
+        assert_ne!(derive_commitment(&env, &s1), derive_commitment(&env, &s2));
+    }
+
+    // ── start_game rejects weak commitments ──────────────────────────────────
+
+    fn setup(env: &Env) -> (soroban_sdk::Address, CoinflipContractClient) {
+        env.mock_all_auths();
+        let contract_id = env.register(CoinflipContract, ());
+        let client = CoinflipContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        let treasury = Address::generate(env);
+        let token = Address::generate(env);
+        client.initialize(&admin, &treasury, &token, &300, &1_000_000, &100_000_000);
+        env.as_contract(&contract_id, || {
+            let mut stats = CoinflipContract::load_stats(env);
+            stats.reserve_balance = i128::MAX / 2;
+            CoinflipContract::save_stats(env, &stats);
+        });
+        (contract_id, client)
+    }
+
+    #[test]
+    fn test_start_game_rejects_all_zero_commitment() {
+        let env = Env::default();
+        let (_, client) = setup(&env);
+        let player = Address::generate(&env);
+        let result = client.try_start_game(
+            &player, &Side::Heads, &10_000_000,
+            &BytesN::from_array(&env, &[0u8; 32]),
+        );
+        assert_eq!(result, Err(Ok(Error::InvalidCommitment)));
+    }
+
+    #[test]
+    fn test_start_game_rejects_all_same_byte_commitment() {
+        let env = Env::default();
+        let (_, client) = setup(&env);
+        let player = Address::generate(&env);
+        let result = client.try_start_game(
+            &player, &Side::Heads, &10_000_000,
+            &BytesN::from_array(&env, &[0xffu8; 32]),
+        );
+        assert_eq!(result, Err(Ok(Error::WeakCommitment)));
+    }
+
+    #[test]
+    fn test_start_game_accepts_strong_commitment() {
+        let env = Env::default();
+        let (_, client) = setup(&env);
+        let player = Address::generate(&env);
+        let secret = Bytes::from_slice(&env, &[1u8; 32]);
+        let commitment = derive_commitment(&env, &secret);
+        assert!(client.try_start_game(&player, &Side::Heads, &10_000_000, &commitment).is_ok());
+    }
+
+    #[test]
+    fn test_continue_streak_rejects_weak_commitment() {
+        let env = Env::default();
+        let (contract_id, client) = setup(&env);
+        let player = Address::generate(&env);
+        let dummy: BytesN<32> = env.crypto().sha256(&Bytes::from_slice(&env, &[9u8; 32])).into();
+        let game = GameState {
+            wager: 10_000_000, side: Side::Heads, streak: 1,
+            commitment: dummy.clone(), contract_random: dummy,
+            fee_bps: 300, phase: GamePhase::Revealed, start_ledger: 0,
+        };
+        env.as_contract(&contract_id, || {
+            CoinflipContract::save_player_game(&env, &player, &game);
+        });
+        let result = client.try_continue_streak(
+            &player, &BytesN::from_array(&env, &[0xaau8; 32]),
+        );
+        assert_eq!(result, Err(Ok(Error::WeakCommitment)));
+    }
+
+    // ── error code stability ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_weak_commitment_error_code() {
+        assert_eq!(Error::WeakCommitment as u32, error_codes::WEAK_COMMITMENT);
+        assert_eq!(error_codes::WEAK_COMMITMENT, 22);
+    }
+
+    // ── property tests ───────────────────────────────────────────────────────
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(200))]
+
+        /// Any SHA-256 output used as a commitment must pass the strength check.
+        #[test]
+        fn prop_sha256_output_always_strong(
+            input in prop::array::uniform32(any::<u8>()),
+        ) {
+            let env = soroban_sdk::Env::default();
+            let bytes = Bytes::from_slice(&env, &input);
+            let commitment: BytesN<32> = env.crypto().sha256(&bytes).into();
+            prop_assert!(validate_commitment_strength(&commitment));
+        }
+
+        /// derive_commitment output always passes the strength check.
+        #[test]
+        fn prop_derive_commitment_always_strong(
+            secret_bytes in prop::array::uniform32(any::<u8>()),
+        ) {
+            let env = soroban_sdk::Env::default();
+            let secret = Bytes::from_slice(&env, &secret_bytes);
+            prop_assert!(validate_commitment_strength(&derive_commitment(&env, &secret)));
+        }
+
+        /// All-same-byte arrays are always weak.
+        #[test]
+        fn prop_all_same_byte_always_weak(byte in any::<u8>()) {
+            let env = soroban_sdk::Env::default();
+            prop_assert!(!validate_commitment_strength(&BytesN::from_array(&env, &[byte; 32])));
+        }
+
+        /// derive_commitment is deterministic across calls.
+        #[test]
+        fn prop_derive_commitment_deterministic(
+            secret_bytes in prop::array::uniform32(any::<u8>()),
+        ) {
+            let env = soroban_sdk::Env::default();
+            let secret = Bytes::from_slice(&env, &secret_bytes);
+            prop_assert_eq!(derive_commitment(&env, &secret), derive_commitment(&env, &secret));
+        }
+
+        /// derive_commitment with domain separation differs from plain SHA-256.
+        #[test]
+        fn prop_derive_commitment_differs_from_plain_sha256(
+            secret_bytes in prop::array::uniform32(any::<u8>()),
+        ) {
+            let env = soroban_sdk::Env::default();
+            let secret = Bytes::from_slice(&env, &secret_bytes);
+            let plain: BytesN<32> = env.crypto().sha256(&secret).into();
+            prop_assert_ne!(derive_commitment(&env, &secret), plain);
+        }
+    }
+}
+
 //
 // Properties:
 //   P-1  After N sequential cash-outs, total_fees equals the sum of each


### PR DESCRIPTION
closes #454 
hat was actually implemented and why:                                                             
                                                                                                     
  The only real front-running attack vector in this contract is the same-ledger reveal:              
  contract_random = SHA-256(ledger_sequence) is deterministic per ledger. If a player submits        
  start_game and reveal in the same ledger, they could observe the ledger sequence before it closes, 
  pre-compute which secret produces a winning outcome, and only submit the reveal if it wins.        
                                                                                                     
  The fix is one guard in reveal:                                                                    
                                                                                                     
  if env.ledger().sequence() <= game.start_ledger {                                                  
      return Err(Error::RevealTooEarly);                                                             
  }                                                                                                  
                                                                                                     
  continue_streak was also updated to refresh start_ledger — without this, the guard would only      
  protect the first round of a streak, not subsequent rounds.                                        
                                                                                                     
  Everything else in the task description ("transaction ordering validation", "suspicious pattern    
  detection", "logging") is not implementable on Soroban — there's no mempool access, no             
  cross-transaction state between ledgers, and the commit-reveal scheme already handles all other    
  front-running vectors by design.        