### PR TITLE
feat: add game history and player statistics tracking

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -365,6 +365,28 @@ pub struct HistoryEntry {
 /// Older entries are evicted in FIFO order once the cap is reached.
 pub const HISTORY_LIMIT: u32 = 100;
 
+/// Player-specific statistics tracking wins, losses, and streaks.
+///
+/// Stored per player and updated on game completion.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PlayerStats {
+    /// Total games played by this player.
+    pub games_played: u64,
+    /// Total wins.
+    pub wins: u64,
+    /// Total losses.
+    pub losses: u64,
+    /// Highest streak achieved.
+    pub max_streak: u32,
+    /// Current active streak (0 if no active game or last game was a loss).
+    pub current_streak: u32,
+    /// Total volume wagered by this player.
+    pub total_wagered: i128,
+    /// Total net winnings (payouts minus wagers).
+    pub net_winnings: i128,
+}
+
 /// Persistent storage key variants for the contract's data model.
 ///
 /// Used with `env.storage().persistent()` for all reads and writes.
@@ -379,6 +401,8 @@ pub enum StorageKey {
     PlayerGame(Address),
     /// Per-player game history ring-buffer ([`Vec<HistoryEntry>`]), keyed by player address.
     PlayerHistory(Address),
+    /// Per-player statistics ([`PlayerStats`]), keyed by player address.
+    PlayerStats(Address),
 }
 
 /// Multiplier values in basis points (1 bps = 0.0001x).
@@ -683,6 +707,32 @@ impl CoinflipContract {
             .remove(&StorageKey::PlayerGame(player.clone()));
     }
 
+    /// Load player statistics. Returns default stats if none exist.
+    fn load_player_stats(env: &Env, player: &Address) -> PlayerStats {
+        let key = StorageKey::PlayerStats(player.clone());
+        if env.storage().persistent().has(&key) {
+            env.storage().persistent().extend_ttl(&key, TTL_THRESHOLD, TTL_EXTEND_TO);
+            env.storage().persistent().get(&key).unwrap()
+        } else {
+            PlayerStats {
+                games_played: 0,
+                wins: 0,
+                losses: 0,
+                max_streak: 0,
+                current_streak: 0,
+                total_wagered: 0,
+                net_winnings: 0,
+            }
+        }
+    }
+
+    /// Save player statistics to persistent storage.
+    fn save_player_stats(env: &Env, player: &Address, stats: &PlayerStats) {
+        let key = StorageKey::PlayerStats(player.clone());
+        env.storage().persistent().set(&key, stats);
+        env.storage().persistent().extend_ttl(&key, TTL_THRESHOLD, TTL_EXTEND_TO);
+    }
+
     /// Append a [`HistoryEntry`] to the player's history ring-buffer.
     ///
     /// Maintains a FIFO cap of [`HISTORY_LIMIT`] entries: when the buffer is
@@ -839,6 +889,12 @@ impl CoinflipContract {
         stats.total_volume = stats.total_volume.checked_add(wager).unwrap_or(stats.total_volume);
         Self::save_stats(&env, &stats);
 
+        // Update player statistics
+        let mut player_stats = Self::load_player_stats(&env, &player);
+        player_stats.games_played = player_stats.games_played.saturating_add(1);
+        player_stats.total_wagered = player_stats.total_wagered.saturating_add(wager);
+        Self::save_player_stats(&env, &player, &player_stats);
+
         Ok(())
     }
 
@@ -914,6 +970,16 @@ impl CoinflipContract {
             game.streak = game.streak.saturating_add(1);
             game.phase = GamePhase::Revealed;
             Self::save_player_game(&env, &player, &game);
+            
+            // Update player stats for win
+            let mut player_stats = Self::load_player_stats(&env, &player);
+            player_stats.wins = player_stats.wins.saturating_add(1);
+            player_stats.current_streak = game.streak;
+            if game.streak > player_stats.max_streak {
+                player_stats.max_streak = game.streak;
+            }
+            Self::save_player_stats(&env, &player, &player_stats);
+            
             Ok(true)
         } else {
             // Loss path — forfeiture:
@@ -934,11 +1000,18 @@ impl CoinflipContract {
                 won: false,
                 streak: 0,
                 commitment: game.commitment,
-                secret,
+                secret: secret.clone(),
                 contract_random: game.contract_random,
                 payout: 0,
                 ledger: game.start_ledger,
             });
+
+            // Update player stats for loss
+            let mut player_stats = Self::load_player_stats(&env, &player);
+            player_stats.losses = player_stats.losses.saturating_add(1);
+            player_stats.current_streak = 0;
+            player_stats.net_winnings = player_stats.net_winnings.saturating_sub(game.wager);
+            Self::save_player_stats(&env, &player, &player_stats);
 
             Self::delete_player_game(&env, &player);
 
@@ -1067,7 +1140,7 @@ impl CoinflipContract {
     ) -> Result<i128, Error> {
         player.require_auth();
 
-        let mut game = Self::load_player_game(&env, &player)
+        let game = Self::load_player_game(&env, &player)
             .ok_or(Error::NoActiveGame)?;
 
         if game.phase != GamePhase::Revealed {
@@ -1109,6 +1182,11 @@ impl CoinflipContract {
             payout: net_payout,
             ledger: game.start_ledger,
         });
+
+        // Update player stats for cash out
+        let mut player_stats = Self::load_player_stats(&env, &player);
+        player_stats.net_winnings = player_stats.net_winnings.saturating_add(net_payout).saturating_sub(game.wager);
+        Self::save_player_stats(&env, &player, &player_stats);
 
         // Clear the player's game state completely after settlement
         Self::delete_player_game(&env, &player);
@@ -1510,6 +1588,17 @@ impl CoinflipContract {
     /// - `None`            – no game record exists for `player`
     pub fn get_game_state(env: Env, player: Address) -> Option<GameState> {
         Self::load_player_game(&env, &player)
+    }
+
+    /// Return the player's statistics.
+    ///
+    /// Read-only; does not require authorization.
+    ///
+    /// # Returns
+    /// The [`PlayerStats`] for the given player, including games played,
+    /// wins, losses, streaks, total wagered, and net winnings.
+    pub fn get_player_stats(env: Env, player: Address) -> PlayerStats {
+        Self::load_player_stats(&env, &player)
     }
 
     /// Return a paginated slice of the player's completed game history.


### PR DESCRIPTION
- Add PlayerStats storage type with games_played, wins, losses, max_streak, current_streak, total_wagered, and net_winnings
- Implement load_player_stats and save_player_stats helper functions
- Update reveal to track wins/losses and update current_streak
- Update cash_out to track net_winnings
- Update start_game to track games_played and total_wagered
- Add get_player_stats public query function for analytics
- Existing get_game_history provides pagination for history
- All stats updated atomically with game state transitions

Closes #482