### PR TITLE
feat: add streak milestone rewards system

### DIFF
--- a/contract/src/arithmetic_tests.rs
+++ b/contract/src/arithmetic_tests.rs
@@ -63,11 +63,11 @@ fn payout_zero_wager_returns_zero() {
 }
 
 /// Test payout breakdown with zero wager.
-/// Should return Some((0, 0, 0)).
+/// Should return Some((0, 0, 0, 0)).
 #[test]
 fn payout_breakdown_zero_wager_returns_zeros() {
     let result = calculate_payout_breakdown(0, 1, 300);
-    assert_eq!(result, Some((0, 0, 0)), "zero wager should return (0, 0, 0)");
+    assert_eq!(result, Some((0, 0, 0, 0)), "zero wager should return (0, 0, 0)");
 }
 
 // ── Boundary: Minimum fee (200 bps) ─────────────────────────────────────────
@@ -88,7 +88,7 @@ fn payout_min_fee_200bps_succeeds() {
 fn payout_breakdown_min_fee_200bps_succeeds() {
     let result = calculate_payout_breakdown(1_000_000, 1, 200);
     assert!(result.is_some(), "minimum fee should not overflow");
-    let (gross, fee, net) = result.unwrap();
+    let (gross, fee, net, _bonus) = result.unwrap();
     assert!(gross > 0, "gross should be positive");
     assert!(fee > 0, "fee should be positive");
     assert!(net > 0, "net should be positive");
@@ -113,7 +113,7 @@ fn payout_max_fee_500bps_succeeds() {
 fn payout_breakdown_max_fee_500bps_succeeds() {
     let result = calculate_payout_breakdown(1_000_000, 1, 500);
     assert!(result.is_some(), "maximum fee should not overflow");
-    let (gross, fee, net) = result.unwrap();
+    let (gross, fee, net, _bonus) = result.unwrap();
     assert!(gross > 0, "gross should be positive");
     assert!(fee > 0, "fee should be positive");
     assert!(net > 0, "net should be positive");
@@ -140,7 +140,7 @@ fn payout_zero_fee_0bps_returns_gross() {
 fn payout_breakdown_zero_fee_0bps_returns_zero_fee() {
     let result = calculate_payout_breakdown(1_000_000, 1, 0);
     assert!(result.is_some(), "zero fee should not overflow");
-    let (gross, fee, net) = result.unwrap();
+    let (gross, fee, net, _bonus) = result.unwrap();
     assert_eq!(fee, 0, "fee should be zero");
     assert_eq!(gross, net, "net should equal gross when fee is zero");
 }
@@ -226,7 +226,7 @@ fn payout_breakdown_invariant_gross_minus_fee_equals_net() {
     ];
 
     for (wager, streak, fee_bps) in test_cases {
-        if let Some((gross, fee, net)) = calculate_payout_breakdown(wager, streak, fee_bps) {
+        if let Some((gross, fee, net, _bonus)) = calculate_payout_breakdown(wager, streak, fee_bps) {
             assert_eq!(
                 gross - fee, net,
                 "invariant failed for wager={}, streak={}, fee_bps={}",
@@ -255,7 +255,7 @@ fn payout_equals_breakdown_net() {
         let breakdown = calculate_payout_breakdown(wager, streak, fee_bps);
 
         match (payout, breakdown) {
-            (Some(p), Some((_, _, net))) => {
+            (Some(p), Some((_, _, net, _))) => {
                 assert_eq!(p, net, "payout should equal net from breakdown");
             }
             (None, None) => {
@@ -283,7 +283,7 @@ fn payout_breakdown_fee_is_non_negative() {
     ];
 
     for (wager, streak, fee_bps) in test_cases {
-        if let Some((_, fee, _)) = calculate_payout_breakdown(wager, streak, fee_bps) {
+        if let Some((_, fee, _, _)) = calculate_payout_breakdown(wager, streak, fee_bps) {
             assert!(fee >= 0, "fee should be non-negative");
         }
     }
@@ -304,7 +304,7 @@ fn payout_breakdown_net_is_non_negative() {
     ];
 
     for (wager, streak, fee_bps) in test_cases {
-        if let Some((_, _, net)) = calculate_payout_breakdown(wager, streak, fee_bps) {
+        if let Some((_, _, net, _)) = calculate_payout_breakdown(wager, streak, fee_bps) {
             assert!(net >= 0, "net should be non-negative");
         }
     }
@@ -330,7 +330,7 @@ fn payout_breakdown_large_safe_wager_succeeds() {
     let large_wager = 1_000_000_000_000i128; // 1 trillion stroops
     let result = calculate_payout_breakdown(large_wager, 1, 300);
     assert!(result.is_some(), "large safe wager should not overflow");
-    let (gross, fee, net) = result.unwrap();
+    let (gross, fee, net, _bonus) = result.unwrap();
     assert!(gross > 0, "gross should be positive");
     assert!(fee > 0, "fee should be positive");
     assert!(net > 0, "net should be positive");

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -434,12 +434,31 @@ pub fn get_multiplier(streak: u32) -> u32 {
     }
 }
 
-/// Calculates the full payout breakdown for a winning streak.
+/// Returns the milestone bonus in basis points for reaching specific streak thresholds.
 ///
-/// Returns `(gross, fee, net)` in stroops, or `None` on arithmetic overflow.
+/// Milestone bonuses incentivize long winning streaks:
+/// - Streak 5:  500 bps (5% bonus)
+/// - Streak 10: 1000 bps (10% bonus)
+/// - Streak 20: 2000 bps (20% bonus)
+///
+/// Returns 0 for non-milestone streaks.
+pub fn get_milestone_bonus_bps(streak: u32) -> u32 {
+    match streak {
+        20 => 2000, // 20% bonus at 20 wins
+        10 => 1000, // 10% bonus at 10 wins
+        5 => 500,   // 5% bonus at 5 wins
+        _ => 0,     // No bonus for other streaks
+    }
+}
+
+/// Calculates the full payout breakdown for a winning streak, including milestone bonuses.
+///
+/// Returns `(gross, fee, net, bonus)` in stroops, or `None` on arithmetic overflow.
 ///
 /// Formulas (all in stroops):
-/// - gross = wager × multiplier_bps / 10_000
+/// - base_gross = wager × multiplier_bps / 10_000
+/// - bonus = base_gross × milestone_bonus_bps / 10_000
+/// - gross = base_gross + bonus
 /// - fee   = gross × fee_bps / 10_000
 /// - net   = gross − fee
 ///
@@ -459,12 +478,18 @@ pub fn get_multiplier(streak: u32) -> u32 {
 /// - `wager`   – original wager in stroops (must be > 0)
 /// - `streak`  – current win streak (passed to `get_multiplier`)
 /// - `fee_bps` – protocol fee in basis points (200–500)
-pub fn calculate_payout_breakdown(wager: i128, streak: u32, fee_bps: u32) -> Option<(i128, i128, i128)> {
+pub fn calculate_payout_breakdown(wager: i128, streak: u32, fee_bps: u32) -> Option<(i128, i128, i128, i128)> {
     let multiplier = get_multiplier(streak) as i128;
-    let gross = wager.checked_mul(multiplier)?.checked_div(10_000)?;
+    let base_gross = wager.checked_mul(multiplier)?.checked_div(10_000)?;
+    
+    // Calculate milestone bonus
+    let bonus_bps = get_milestone_bonus_bps(streak) as i128;
+    let bonus = base_gross.checked_mul(bonus_bps)?.checked_div(10_000)?;
+    
+    let gross = base_gross.checked_add(bonus)?;
     let fee   = gross.checked_mul(fee_bps as i128)?.checked_div(10_000)?;
     let net   = gross.checked_sub(fee)?;
-    Some((gross, fee, net))
+    Some((gross, fee, net, bonus))
 }
 
 /// Calculates the net payout for a winning streak.
@@ -479,7 +504,7 @@ pub fn calculate_payout_breakdown(wager: i128, streak: u32, fee_bps: u32) -> Opt
 /// - `streak`  – current win streak (passed to `get_multiplier`)
 /// - `fee_bps` – protocol fee in basis points (200–500)
 pub fn calculate_payout(wager: i128, streak: u32, fee_bps: u32) -> Option<i128> {
-    calculate_payout_breakdown(wager, streak, fee_bps).map(|(_, _, net)| net)
+    calculate_payout_breakdown(wager, streak, fee_bps).map(|(_, _, net, _)| net)
 }
 
 /// Helper to verify a player's commitment hash.
@@ -1006,7 +1031,7 @@ impl CoinflipContract {
         // Single-pass payout breakdown: gross, fee, and net computed together to
         // avoid the duplicate multiplier lookup + two checked_div calls that would
         // result from calling calculate_payout and then recomputing gross/fee.
-        let (gross_payout, fee_amount, net_payout) =
+        let (gross_payout, fee_amount, net_payout, _bonus) =
             calculate_payout_breakdown(game.wager, game.streak, game.fee_bps)
                 .ok_or(Error::InsufficientReserves)?;
 
@@ -1081,7 +1106,7 @@ impl CoinflipContract {
         // Single-pass payout breakdown: gross, fee, and net computed together to
         // avoid the duplicate multiplier lookup + two checked_div calls that would
         // result from calling calculate_payout and then recomputing gross/fee.
-        let (gross, fee, net_payout) =
+        let (gross, fee, net_payout, _bonus) =
             calculate_payout_breakdown(game.wager, game.streak, game.fee_bps)
                 .ok_or(Error::InsufficientReserves)?;
 
@@ -1727,7 +1752,7 @@ mod tests {
         // net   = 18_430_000
         assert_eq!(
             calculate_payout_breakdown(10_000_000, 1, 300).unwrap(),
-            Some((19_000_000, 570_000, 18_430_000))
+            Some((19_000_000, 570_000, 18_430_000, 0)) // No milestone bonus at streak 1
         );
     }
 
@@ -1735,7 +1760,7 @@ mod tests {
     fn test_calculate_payout_breakdown_net_equals_calculate_payout() {
         // calculate_payout must return the same net as the breakdown helper
         for (wager, streak, fee_bps) in [(10_000_000, 1, 300), (5_000_000, 2, 500), (1_000_000, 4, 200)] {
-            let (_, _, net) = calculate_payout_breakdown(wager, streak, fee_bps).unwrap().unwrap();
+            let (_, _, net, _) = calculate_payout_breakdown(wager, streak, fee_bps).unwrap().unwrap();
             assert_eq!(calculate_payout(wager, streak, fee_bps).unwrap(), Some(net));
         }
     }
@@ -1743,7 +1768,7 @@ mod tests {
     #[test]
     fn test_calculate_payout_breakdown_gross_minus_fee_equals_net() {
         // Invariant: gross - fee == net for all valid inputs
-        let (gross, fee, net) = calculate_payout_breakdown(10_000_000, 3, 400).unwrap().unwrap();
+        let (gross, fee, net, _) = calculate_payout_breakdown(10_000_000, 3, 400).unwrap().unwrap();
         assert_eq!(gross - fee, net);
     }
 
@@ -8176,7 +8201,7 @@ mod cash_out_availability_tests {
             let net = client.cash_out(&player);
 
             // Compute expected values using the same helpers the contract uses.
-            let (expected_gross, expected_fee, expected_net) =
+            let             (expected_gross, expected_fee, expected_net, _bonus) =
                 calculate_payout_breakdown(wager, streak, 300).unwrap();
 
             prop_assert_eq!(net, expected_net,

--- a/contract/src/multiplier_tests.rs
+++ b/contract/src/multiplier_tests.rs
@@ -168,7 +168,7 @@ fn payout_higher_fee_produces_lower_net() {
 /// gross = 10_000_000 × 19_000 / 10_000 = 19_000_000
 #[test]
 fn payout_fee_zero_net_equals_gross() {
-    let (gross, fee, net) = calculate_payout_breakdown(10_000_000, 1, 0).unwrap().unwrap();
+    let (gross, fee, net, _bonus) = calculate_payout_breakdown(10_000_000, 1, 0).unwrap().unwrap();
     assert_eq!(fee, 0);
     assert_eq!(net, gross);
 }
@@ -176,7 +176,7 @@ fn payout_fee_zero_net_equals_gross() {
 /// Fee 10_000 bps (100%): net must be 0 (all gross taken as fee).
 #[test]
 fn payout_fee_10000_net_is_zero() {
-    let (gross, fee, net) = calculate_payout_breakdown(10_000_000, 1, 10_000).unwrap().unwrap();
+    let (gross, fee, net, _bonus) = calculate_payout_breakdown(10_000_000, 1, 10_000).unwrap().unwrap();
     assert_eq!(fee, gross);
     assert_eq!(net, 0);
 }
@@ -192,7 +192,7 @@ fn payout_wager_1_stroop_returns_some() {
 /// Zero wager: gross, fee, and net must all be 0.
 #[test]
 fn payout_wager_zero_all_components_zero() {
-    let (gross, fee, net) = calculate_payout_breakdown(0, 1, 300).unwrap().unwrap();
+    let (gross, fee, net, _bonus) = calculate_payout_breakdown(0, 1, 300).unwrap().unwrap();
     assert_eq!(gross, 0);
     assert_eq!(fee, 0);
     assert_eq!(net, 0);
@@ -253,7 +253,7 @@ fn payout_near_overflow_boundary_returns_some() {
 /// Streak 1 full breakdown.
 #[test]
 fn breakdown_streak_1_all_components() {
-    let (gross, fee, net) = calculate_payout_breakdown(10_000_000, 1, 300).unwrap().unwrap();
+    let (gross, fee, net, _bonus) = calculate_payout_breakdown(10_000_000, 1, 300).unwrap().unwrap();
     assert_eq!(gross, 19_000_000);
     assert_eq!(fee, 570_000);
     assert_eq!(net, 18_430_000);
@@ -265,7 +265,7 @@ fn breakdown_streak_1_all_components() {
 /// net   = 33_950_000
 #[test]
 fn breakdown_streak_2_all_components() {
-    let (gross, fee, net) = calculate_payout_breakdown(10_000_000, 2, 300).unwrap().unwrap();
+    let (gross, fee, net, _bonus) = calculate_payout_breakdown(10_000_000, 2, 300).unwrap().unwrap();
     assert_eq!(gross, 35_000_000);
     assert_eq!(fee, 1_050_000);
     assert_eq!(net, 33_950_000);
@@ -277,7 +277,7 @@ fn breakdown_streak_2_all_components() {
 /// net   = 58_200_000
 #[test]
 fn breakdown_streak_3_all_components() {
-    let (gross, fee, net) = calculate_payout_breakdown(10_000_000, 3, 300).unwrap().unwrap();
+    let (gross, fee, net, _bonus) = calculate_payout_breakdown(10_000_000, 3, 300).unwrap().unwrap();
     assert_eq!(gross, 60_000_000);
     assert_eq!(fee, 1_800_000);
     assert_eq!(net, 58_200_000);
@@ -289,7 +289,7 @@ fn breakdown_streak_3_all_components() {
 /// net   = 97_000_000
 #[test]
 fn breakdown_streak_4_all_components() {
-    let (gross, fee, net) = calculate_payout_breakdown(10_000_000, 4, 300).unwrap().unwrap();
+    let (gross, fee, net, _bonus) = calculate_payout_breakdown(10_000_000, 4, 300).unwrap().unwrap();
     assert_eq!(gross, 100_000_000);
     assert_eq!(fee, 3_000_000);
     assert_eq!(net, 97_000_000);
@@ -318,7 +318,7 @@ fn invariant_gross_minus_fee_equals_net() {
         (5_000_000, 2, 400),
     ];
     for &(wager, streak, fee_bps) in cases {
-        let (gross, fee, net) = calculate_payout_breakdown(wager, streak, fee_bps).unwrap().unwrap();
+        let (gross, fee, net, _bonus) = calculate_payout_breakdown(wager, streak, fee_bps).unwrap().unwrap();
         assert_eq!(
             gross - fee,
             net,
@@ -339,7 +339,7 @@ fn invariant_payout_net_matches_breakdown_net() {
         (50_000_000, 3, 300),
     ];
     for &(wager, streak, fee_bps) in cases {
-        let (_, _, breakdown_net) = calculate_payout_breakdown(wager, streak, fee_bps).unwrap().unwrap();
+        let (_, _, breakdown_net, _) = calculate_payout_breakdown(wager, streak, fee_bps).unwrap().unwrap();
         let payout_net = calculate_payout(wager, streak, fee_bps).unwrap().unwrap();
         assert_eq!(
             payout_net,
@@ -354,7 +354,7 @@ fn invariant_payout_net_matches_breakdown_net() {
 fn invariant_net_never_exceeds_gross() {
     for streak in [1, 2, 3, 4] {
         for fee_bps in [200, 300, 400, 500] {
-            let (gross, _fee, net) = calculate_payout_breakdown(10_000_000, streak, fee_bps).unwrap().unwrap();
+            let (gross, _fee, net, _bonus) = calculate_payout_breakdown(10_000_000, streak, fee_bps).unwrap().unwrap();
             assert!(
                 net <= gross,
                 "net({net}) > gross({gross}) for streak={streak} fee_bps={fee_bps}"
@@ -368,7 +368,7 @@ fn invariant_net_never_exceeds_gross() {
 fn invariant_gross_always_greater_than_wager() {
     let wager = 10_000_000_i128;
     for streak in [1, 2, 3, 4] {
-        let (gross, _fee, _net) = calculate_payout_breakdown(wager, streak, 300).unwrap().unwrap();
+        let (gross, _fee, _net, _bonus) = calculate_payout_breakdown(wager, streak, 300).unwrap().unwrap();
         assert!(
             gross > wager,
             "gross({gross}) should be > wager({wager}) for streak={streak}"
@@ -381,10 +381,10 @@ fn invariant_gross_always_greater_than_wager() {
 fn invariant_higher_streak_produces_higher_gross() {
     let wager = 10_000_000_i128;
     let fee_bps = 300_u32;
-    let (gross1, _, _) = calculate_payout_breakdown(wager, 1, fee_bps).unwrap().unwrap();
-    let (gross2, _, _) = calculate_payout_breakdown(wager, 2, fee_bps).unwrap().unwrap();
-    let (gross3, _, _) = calculate_payout_breakdown(wager, 3, fee_bps).unwrap().unwrap();
-    let (gross4, _, _) = calculate_payout_breakdown(wager, 4, fee_bps).unwrap().unwrap();
+    let (gross1, _, _, _) = calculate_payout_breakdown(wager, 1, fee_bps).unwrap().unwrap();
+    let (gross2, _, _, _) = calculate_payout_breakdown(wager, 2, fee_bps).unwrap().unwrap();
+    let (gross3, _, _, _) = calculate_payout_breakdown(wager, 3, fee_bps).unwrap().unwrap();
+    let (gross4, _, _, _) = calculate_payout_breakdown(wager, 4, fee_bps).unwrap().unwrap();
     assert!(gross1 < gross2);
     assert!(gross2 < gross3);
     assert!(gross3 < gross4);
@@ -396,8 +396,8 @@ fn invariant_higher_streak_produces_higher_gross() {
 fn invariant_payout_scales_linearly_with_wager() {
     let fee_bps = 300_u32;
     for streak in [1, 2, 3, 4] {
-        let (g1, f1, n1) = calculate_payout_breakdown(10_000_000, streak, fee_bps).unwrap().unwrap();
-        let (g2, f2, n2) = calculate_payout_breakdown(20_000_000, streak, fee_bps).unwrap().unwrap();
+        let (g1, f1, n1, _) = calculate_payout_breakdown(10_000_000, streak, fee_bps).unwrap().unwrap();
+        let (g2, f2, n2, _) = calculate_payout_breakdown(20_000_000, streak, fee_bps).unwrap().unwrap();
         assert_eq!(g2, g1 * 2, "gross should double for streak={streak}");
         assert_eq!(f2, f1 * 2, "fee should double for streak={streak}");
         assert_eq!(n2, n1 * 2, "net should double for streak={streak}");
@@ -498,7 +498,7 @@ fn multiplier_tier_transition_4_to_5_cap_plateau() {
 #[test]
 fn multiplier_payout_tier_1_1_9x() {
     let wager = 10_000_000i128;
-    let (gross, fee, net) = calculate_payout_breakdown(wager, 1, 300).unwrap().unwrap();
+    let (gross, fee, net, _bonus) = calculate_payout_breakdown(wager, 1, 300).unwrap().unwrap();
     assert_eq!(gross, 19_000_000, "tier 1 gross should be 1.9x wager");
     assert_eq!(fee, 570_000, "tier 1 fee should be 3% of gross");
     assert_eq!(net, 18_430_000, "tier 1 net should be gross - fee");
@@ -508,7 +508,7 @@ fn multiplier_payout_tier_1_1_9x() {
 #[test]
 fn multiplier_payout_tier_2_3_5x() {
     let wager = 10_000_000i128;
-    let (gross, fee, net) = calculate_payout_breakdown(wager, 2, 300).unwrap().unwrap();
+    let (gross, fee, net, _bonus) = calculate_payout_breakdown(wager, 2, 300).unwrap().unwrap();
     assert_eq!(gross, 35_000_000, "tier 2 gross should be 3.5x wager");
     assert_eq!(fee, 1_050_000, "tier 2 fee should be 3% of gross");
     assert_eq!(net, 33_950_000, "tier 2 net should be gross - fee");
@@ -518,7 +518,7 @@ fn multiplier_payout_tier_2_3_5x() {
 #[test]
 fn multiplier_payout_tier_3_6_0x() {
     let wager = 10_000_000i128;
-    let (gross, fee, net) = calculate_payout_breakdown(wager, 3, 300).unwrap().unwrap();
+    let (gross, fee, net, _bonus) = calculate_payout_breakdown(wager, 3, 300).unwrap().unwrap();
     assert_eq!(gross, 60_000_000, "tier 3 gross should be 6.0x wager");
     assert_eq!(fee, 1_800_000, "tier 3 fee should be 3% of gross");
     assert_eq!(net, 58_200_000, "tier 3 net should be gross - fee");
@@ -528,7 +528,7 @@ fn multiplier_payout_tier_3_6_0x() {
 #[test]
 fn multiplier_payout_tier_4_plus_10_0x() {
     let wager = 10_000_000i128;
-    let (gross, fee, net) = calculate_payout_breakdown(wager, 4, 300).unwrap().unwrap();
+    let (gross, fee, net, _bonus) = calculate_payout_breakdown(wager, 4, 300).unwrap().unwrap();
     assert_eq!(gross, 100_000_000, "tier 4+ gross should be 10.0x wager");
     assert_eq!(fee, 3_000_000, "tier 4+ fee should be 3% of gross");
     assert_eq!(net, 97_000_000, "tier 4+ net should be gross - fee");


### PR DESCRIPTION
- Implement milestone detection (5, 10, 20 wins)
- Add bonus calculation (5%/10%/20% of base payout)
- Update payout breakdown to include milestone bonuses
- Track milestone achievements in payout calculations

Closes #481