### PR TITLE
test: add statistics accuracy property coverage

### DIFF
--- a/contract/src/statistics_tests.rs
+++ b/contract/src/statistics_tests.rs
@@ -1,21 +1,34 @@
 /// Property-based tests for contract statistics accuracy.
 ///
-/// Issue: add-property-tests-statistics-accuracy
+/// # Stat Semantics
 ///
-/// Covers:
-///   - Property 29: Statistics accuracy test
-///   - total_games increments correctly
-///   - total_volume accumulates all wagers
-///   - total_fees accumulates all collected fees
-///   - reserve_balance updates correctly
-///   - 100+ iterations with various game sequences
-///   - Stats never decrease incorrectly
+/// | Field             | Updated by          | Direction  | Invariant                                      |
+/// |-------------------|---------------------|------------|------------------------------------------------|
+/// | `total_games`     | `start_game`        | +1         | Strictly monotone; never decremented           |
+/// | `total_volume`    | `start_game`        | +wager     | Strictly monotone; never decremented           |
+/// | `total_fees`      | `cash_out` / `claim_winnings` | +fee | Monotone; only increases on settled wins  |
+/// | `reserve_balance` | `start_game` (check only), `reveal` (loss: +wager), `cash_out` / `claim_winnings` (win: -gross) | ± | Must stay ≥ 0 |
+///
+/// # Coverage
+///
+/// - Property 29a: `total_games` increments by exactly 1 per `start_game`
+/// - Property 29b: `total_volume` increases by exactly the wager per `start_game`
+/// - Property 29c: `total_fees` increases by exactly the fee on `cash_out`
+/// - Property 29d: `reserve_balance` decreases by gross payout on `cash_out`
+/// - Property 29e: `reserve_balance` increases by wager on loss forfeiture
+/// - Property 29f: `total_games` and `total_volume` are monotonically non-decreasing
+/// - Multi-game sequences: concurrent starts, mixed win/loss/continue flows
+/// - Edge cases: failed starts, 100-game accumulation, fee-free loss path
 use super::*;
 use soroban_sdk::testutils::Address as _;
 use proptest::prelude::*;
 
 // ── Harness ───────────────────────────────────────────────────────────────────
 
+/// Set up a fresh contract environment with default config.
+///
+/// Returns `(env, client, contract_id)`.
+/// Config: fee=300bps, min_wager=1_000_000, max_wager=100_000_000.
 fn setup() -> (Env, CoinflipContractClient<'static>, Address) {
     let env = Env::default();
     env.mock_all_auths();
@@ -28,6 +41,7 @@ fn setup() -> (Env, CoinflipContractClient<'static>, Address) {
     (env, client, contract_id)
 }
 
+/// Directly set `reserve_balance` in stats storage, bypassing `start_game` guards.
 fn fund(env: &Env, contract_id: &Address, amount: i128) {
     env.as_contract(contract_id, || {
         let mut stats = CoinflipContract::load_stats(env);
@@ -36,6 +50,7 @@ fn fund(env: &Env, contract_id: &Address, amount: i128) {
     });
 }
 
+/// Build a 32-byte `Bytes` value filled with `seed`.
 fn make_secret(env: &Env, seed: u8) -> Bytes {
     let mut b = Bytes::new(env);
     for _ in 0..32 {
@@ -44,14 +59,20 @@ fn make_secret(env: &Env, seed: u8) -> Bytes {
     b
 }
 
+/// SHA-256 of a 32-byte secret filled with `seed`.
 fn make_commitment(env: &Env, seed: u8) -> BytesN<32> {
     env.crypto().sha256(&make_secret(env, seed)).into()
 }
 
+/// Read stats from inside the contract's storage context.
 fn load_stats(env: &Env, contract_id: &Address) -> ContractStats {
     env.as_contract(contract_id, || CoinflipContract::load_stats(env))
 }
 
+/// Inject a `GameState` directly into storage, bypassing `start_game` guards.
+///
+/// Useful for testing settlement paths (`cash_out`, `claim_winnings`) in
+/// isolation without needing a valid commit-reveal sequence.
 fn inject_game(
     env: &Env,
     contract_id: &Address,
@@ -106,7 +127,7 @@ fn test_total_games_increments_for_each_new_game() {
 #[test]
 fn test_total_games_does_not_increment_on_failed_start() {
     let (env, client, contract_id) = setup();
-    // No reserves — start_game will fail
+    // No reserves — start_game will fail with InsufficientReserves
     let player = Address::generate(&env);
     let _ = client.try_start_game(&player, &Side::Heads, &5_000_000, &make_commitment(&env, 1));
     assert_eq!(load_stats(&env, &contract_id).total_games, 0);
@@ -119,6 +140,7 @@ fn test_total_games_does_not_increment_on_reveal_or_cash_out() {
     let player = Address::generate(&env);
     client.start_game(&player, &Side::Heads, &5_000_000, &make_commitment(&env, 1));
     let before = load_stats(&env, &contract_id).total_games;
+    // reveal + cash_out must not change total_games
     client.reveal(&player, &make_secret(&env, 1));
     client.cash_out(&player);
     assert_eq!(load_stats(&env, &contract_id).total_games, before);
@@ -164,6 +186,7 @@ fn test_total_volume_does_not_change_on_cash_out() {
     let before = load_stats(&env, &contract_id).total_volume;
     client.reveal(&player, &make_secret(&env, 1));
     client.cash_out(&player);
+    // total_volume must not change after reveal/cash_out
     assert_eq!(load_stats(&env, &contract_id).total_volume, before);
 }
 
@@ -181,9 +204,10 @@ fn test_total_fees_accumulates_on_cash_out() {
     fund(&env, &contract_id, 1_000_000_000);
     let wager = 10_000_000i128;
     let player = Address::generate(&env);
+    // Inject a Revealed game at streak=1 so cash_out settles it
     inject_game(&env, &contract_id, &player, GamePhase::Revealed, 1, wager);
     client.cash_out(&player);
-    // gross=19_000_000, fee=570_000 (300bps)
+    // gross = 10_000_000 * 1.9 = 19_000_000; fee = 19_000_000 * 300/10_000 = 570_000
     let expected_fee = 570_000i128;
     assert_eq!(load_stats(&env, &contract_id).total_fees, expected_fee);
 }
@@ -209,11 +233,12 @@ fn test_total_fees_does_not_accumulate_on_loss() {
     let (env, client, contract_id) = setup();
     fund(&env, &contract_id, 1_000_000_000);
     let player = Address::generate(&env);
-    // Seed 3 → loss for Heads player
+    // Seed 3 → loss for Heads player (verified by generate_outcome logic)
     let secret = make_secret(&env, 3);
     let commitment = make_commitment(&env, 3);
     client.start_game(&player, &Side::Heads, &5_000_000, &commitment);
     client.reveal(&player, &secret);
+    // No fee should be collected on a loss
     assert_eq!(load_stats(&env, &contract_id).total_fees, 0);
 }
 
@@ -228,9 +253,12 @@ fn test_reserve_balance_decreases_by_gross_on_cash_out() {
     let player = Address::generate(&env);
     inject_game(&env, &contract_id, &player, GamePhase::Revealed, 1, wager);
     client.cash_out(&player);
-    // gross = 10_000_000 * 1.9 = 19_000_000
-    let expected_reserve = initial_reserve - 19_000_000;
-    assert_eq!(load_stats(&env, &contract_id).reserve_balance, expected_reserve);
+    // gross = 10_000_000 * 19_000 / 10_000 = 19_000_000
+    let (gross, _, _) = calculate_payout_breakdown(wager, 1, 300).unwrap();
+    assert_eq!(
+        load_stats(&env, &contract_id).reserve_balance,
+        initial_reserve - gross
+    );
 }
 
 #[test]
@@ -240,11 +268,12 @@ fn test_reserve_balance_increases_on_loss() {
     fund(&env, &contract_id, initial_reserve);
     let wager = 5_000_000i128;
     let player = Address::generate(&env);
-    // Seed 3 → loss
+    // Seed 3 → loss for Heads player
     let secret = make_secret(&env, 3);
     let commitment = make_commitment(&env, 3);
     client.start_game(&player, &Side::Heads, &wager, &commitment);
     client.reveal(&player, &secret);
+    // On loss, wager is forfeited to reserves
     assert_eq!(
         load_stats(&env, &contract_id).reserve_balance,
         initial_reserve + wager
@@ -258,8 +287,23 @@ fn test_reserve_balance_unchanged_on_continue_streak() {
     let player = Address::generate(&env);
     inject_game(&env, &contract_id, &player, GamePhase::Revealed, 1, 5_000_000);
     let before = load_stats(&env, &contract_id).reserve_balance;
+    // continue_streak transitions phase but does not touch reserve_balance
     client.continue_streak(&player, &make_commitment(&env, 42));
     assert_eq!(load_stats(&env, &contract_id).reserve_balance, before);
+}
+
+#[test]
+fn test_reserve_balance_unchanged_by_start_game() {
+    // start_game only checks reserve_balance; it does not decrement it.
+    let (env, client, contract_id) = setup();
+    let initial_reserve = 1_000_000_000i128;
+    fund(&env, &contract_id, initial_reserve);
+    let player = Address::generate(&env);
+    client.start_game(&player, &Side::Heads, &5_000_000, &make_commitment(&env, 1));
+    assert_eq!(
+        load_stats(&env, &contract_id).reserve_balance,
+        initial_reserve
+    );
 }
 
 // ── Stats never decrease incorrectly ─────────────────────────────────────────
@@ -312,7 +356,7 @@ fn test_total_fees_never_decreases() {
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(100))]
 
-    /// PROPERTY 29a: total_games increments by exactly 1 per start_game call.
+    /// PROPERTY 29a: `total_games` increments by exactly 1 per `start_game` call.
     #[test]
     fn prop_29a_total_games_increments_by_one(
         wager in 1_000_000i128..=100_000_000i128,
@@ -327,7 +371,7 @@ proptest! {
         prop_assert_eq!(after, before + 1);
     }
 
-    /// PROPERTY 29b: total_volume increases by exactly the wager on each start_game.
+    /// PROPERTY 29b: `total_volume` increases by exactly the wager on each `start_game`.
     #[test]
     fn prop_29b_total_volume_increases_by_wager(
         wager in 1_000_000i128..=100_000_000i128,
@@ -342,7 +386,10 @@ proptest! {
         prop_assert_eq!(after, before + wager);
     }
 
-    /// PROPERTY 29c: total_fees increases by exactly the fee amount on cash_out.
+    /// PROPERTY 29c: `total_fees` increases by exactly the fee amount on `cash_out`.
+    ///
+    /// Uses `inject_game` to place a `Revealed` game with a known `fee_bps` snapshot,
+    /// then verifies the fee delta matches `calculate_payout_breakdown`.
     #[test]
     fn prop_29c_total_fees_increases_by_fee_on_cash_out(
         wager in 1_000_000i128..=100_000_000i128,
@@ -351,12 +398,8 @@ proptest! {
     ) {
         let (env, client, contract_id) = setup();
         fund(&env, &contract_id, 1_000_000_000_000i128);
-        env.as_contract(&contract_id, || {
-            let mut config = CoinflipContract::load_config(&env);
-            config.fee_bps = fee_bps;
-            CoinflipContract::save_config(&env, &config);
-        });
         let player = Address::generate(&env);
+        // Inject a Revealed game with the property-generated fee_bps snapshot
         let game = GameState {
             wager,
             side: Side::Heads,
@@ -377,7 +420,7 @@ proptest! {
         prop_assert_eq!(after, before + expected_fee);
     }
 
-    /// PROPERTY 29d: reserve_balance decreases by gross payout on cash_out.
+    /// PROPERTY 29d: `reserve_balance` decreases by gross payout on `cash_out`.
     #[test]
     fn prop_29d_reserve_decreases_by_gross_on_cash_out(
         wager in 1_000_000i128..=100_000_000i128,
@@ -406,7 +449,11 @@ proptest! {
         prop_assert_eq!(after, before - gross);
     }
 
-    /// PROPERTY 29e: reserve_balance increases by wager on loss (forfeiture).
+    /// PROPERTY 29e: `reserve_balance` increases by wager on loss forfeiture.
+    ///
+    /// Uses seed=3 which is known to produce a loss for a Heads player.
+    /// `prop_assume!(!won)` guards against the rare case where the seed
+    /// produces a win (should not happen for seed=3, but is defensive).
     #[test]
     fn prop_29e_reserve_increases_by_wager_on_loss(
         wager in 1_000_000i128..=100_000_000i128,
@@ -414,12 +461,7 @@ proptest! {
         let (env, client, contract_id) = setup();
         fund(&env, &contract_id, 1_000_000_000_000i128);
         let player = Address::generate(&env);
-        // Seed 3 → loss for Heads player
-        let secret = {
-            let mut b = Bytes::new(&env);
-            for _ in 0..32 { b.push_back(3u8); }
-            b
-        };
+        let secret = make_secret(&env, 3);
         let commitment: BytesN<32> = env.crypto().sha256(&secret).into();
         client.start_game(&player, &Side::Heads, &wager, &commitment);
         let before = load_stats(&env, &contract_id).reserve_balance;
@@ -429,8 +471,8 @@ proptest! {
         prop_assert_eq!(after, before + wager);
     }
 
-    /// PROPERTY 29f: total_games, total_volume are monotonically non-decreasing
-    /// across a sequence of game starts.
+    /// PROPERTY 29f: `total_games` and `total_volume` are monotonically non-decreasing
+    /// across a sequence of `start_game` calls with varying wagers.
     #[test]
     fn prop_29f_stats_monotonically_non_decreasing(
         num_games in 1usize..=10usize,
@@ -444,45 +486,48 @@ proptest! {
             let commitment = BytesN::from_array(&env, &[i as u8 + 1; 32]);
             client.start_game(&player, &Side::Heads, &wager, &commitment);
             let curr = load_stats(&env, &contract_id);
-            prop_assert!(curr.total_games >= prev.total_games);
-            prop_assert!(curr.total_volume >= prev.total_volume);
+            prop_assert!(curr.total_games >= prev.total_games,
+                "total_games decreased: {} -> {}", prev.total_games, curr.total_games);
+            prop_assert!(curr.total_volume >= prev.total_volume,
+                "total_volume decreased: {} -> {}", prev.total_volume, curr.total_volume);
             prev = curr;
         }
     }
 }
 
-// ── Concurrent statistics update tests ─────────────────────────────────────────
+// ── Multi-game sequence tests ─────────────────────────────────────────────────
 
+/// Verify that starting N games from distinct players accumulates stats correctly.
+/// Uses counters instead of std::Vec to stay no_std compatible.
 #[test]
 fn test_concurrent_games_accumulate_statistics() {
     let (env, client, contract_id) = setup();
     fund(&env, &contract_id, 1_000_000_000_000);
-    
-    // Start multiple games concurrently
-    let mut players = Vec::new();
-    let mut wagers = Vec::new();
+
+    let mut expected_volume = 0i128;
     for i in 0u8..10 {
         let player = Address::generate(&env);
         let wager = 1_000_000i128 * (i as i128 + 1);
-        wagers.push(wager);
+        expected_volume += wager;
         client.start_game(&player, &Side::Heads, &wager, &make_commitment(&env, i + 1));
-        players.push(player);
     }
-    
-    // Verify total_games incremented correctly
-    assert_eq!(load_stats(&env, &contract_id).total_games, 10);
-    
-    // Verify total_volume is sum of all wagers
-    let expected_volume: i128 = wagers.iter().sum();
-    assert_eq!(load_stats(&env, &contract_id).total_volume, expected_volume);
+
+    let stats = load_stats(&env, &contract_id);
+    assert_eq!(stats.total_games, 10);
+    assert_eq!(stats.total_volume, expected_volume);
 }
 
+/// Verify that settling N games accumulates `total_fees` correctly.
+///
+/// Bug fix: the original test injected one set of players to compute
+/// `expected_fees`, then injected a *different* set of players to cash out,
+/// so the expected and actual values were unrelated.  This version injects
+/// and cashes out the same player in each iteration.
 #[test]
 fn test_concurrent_settlements_accumulate_fees() {
     let (env, client, contract_id) = setup();
     fund(&env, &contract_id, 1_000_000_000_000);
-    
-    // Create multiple games in Revealed phase
+
     let mut expected_fees = 0i128;
     for i in 0u32..5 {
         let player = Address::generate(&env);
@@ -491,41 +536,36 @@ fn test_concurrent_settlements_accumulate_fees() {
         inject_game(&env, &contract_id, &player, GamePhase::Revealed, streak, wager);
         let (_gross, fee, _net) = calculate_payout_breakdown(wager, streak, 300).unwrap();
         expected_fees += fee;
-    }
-    
-    // Cash out all games
-    for i in 0u32..5 {
-        let player = Address::generate(&env);
-        let wager = 10_000_000i128;
-        let streak = (i % 4) + 1;
-        inject_game(&env, &contract_id, &player, GamePhase::Revealed, streak, wager);
         client.cash_out(&player);
     }
-    
-    // Verify total_fees accumulated correctly
+
     assert_eq!(load_stats(&env, &contract_id).total_fees, expected_fees);
 }
 
+/// Verify that a mix of wins and losses produces the correct `reserve_balance`.
+///
+/// - 3 winning cash-outs each deduct `gross` from reserves.
+/// - 2 losses each add `wager` to reserves.
 #[test]
 fn test_concurrent_wins_and_losses_update_reserve() {
     let (env, client, contract_id) = setup();
     let initial_reserve = 1_000_000_000i128;
     fund(&env, &contract_id, initial_reserve);
-    
+
     let mut net_change = 0i128;
-    
-    // Create 3 winning games
-    for i in 0u8..3 {
+
+    // 3 winning cash-outs
+    for _ in 0u8..3 {
         let player = Address::generate(&env);
         let wager = 5_000_000i128;
         inject_game(&env, &contract_id, &player, GamePhase::Revealed, 1, wager);
-        let (gross, _fee, _net) = calculate_payout_breakdown(wager, 1, 300).unwrap();
+        let (gross, _, _) = calculate_payout_breakdown(wager, 1, 300).unwrap();
         net_change -= gross;
         client.cash_out(&player);
     }
-    
-    // Create 2 losing games
-    for i in 0u8..2 {
+
+    // 2 losses (seed 3 → Tails outcome, Heads player loses)
+    for _ in 0u8..2 {
         let player = Address::generate(&env);
         let wager = 5_000_000i128;
         let secret = make_secret(&env, 3);
@@ -534,81 +574,134 @@ fn test_concurrent_wins_and_losses_update_reserve() {
         client.reveal(&player, &secret);
         net_change += wager;
     }
-    
-    // Verify reserve_balance reflects all changes
-    let expected_reserve = initial_reserve + net_change;
-    assert_eq!(load_stats(&env, &contract_id).reserve_balance, expected_reserve);
+
+    assert_eq!(
+        load_stats(&env, &contract_id).reserve_balance,
+        initial_reserve + net_change
+    );
 }
 
+/// Verify stat consistency across a mixed sequence: win+cash_out, loss, win+continue.
+///
+/// Uses `inject_game` for the win paths to avoid dependence on seed-based
+/// outcome determinism for non-loss seeds.
 #[test]
 fn test_statistics_consistency_with_mixed_operations() {
     let (env, client, contract_id) = setup();
     fund(&env, &contract_id, 1_000_000_000_000);
-    
-    // Mix of operations: start, reveal wins, reveal losses, continue
+
     let player1 = Address::generate(&env);
     let player2 = Address::generate(&env);
     let player3 = Address::generate(&env);
-    
-    // Player 1: start and win
-    client.start_game(&player1, &Side::Heads, &10_000_000, &make_commitment(&env, 1));
-    client.reveal(&player1, &make_secret(&env, 1));
+
+    // Player 1: injected win → cash_out
+    inject_game(&env, &contract_id, &player1, GamePhase::Revealed, 1, 10_000_000);
     client.cash_out(&player1);
-    
-    // Player 2: start and lose
+
+    // Player 2: real start → loss (seed 3 → Tails, Heads player loses)
     let secret2 = make_secret(&env, 3);
     let commitment2 = make_commitment(&env, 3);
     client.start_game(&player2, &Side::Heads, &5_000_000, &commitment2);
     client.reveal(&player2, &secret2);
-    
-    // Player 3: start, win, continue
-    client.start_game(&player3, &Side::Heads, &7_000_000, &make_commitment(&env, 2));
-    client.reveal(&player3, &make_secret(&env, 2));
+
+    // Player 3: injected win → continue_streak
+    inject_game(&env, &contract_id, &player3, GamePhase::Revealed, 1, 7_000_000);
     client.continue_streak(&player3, &make_commitment(&env, 42));
-    
-    // Verify statistics
+
     let stats = load_stats(&env, &contract_id);
-    assert_eq!(stats.total_games, 3); // 3 start_game calls
-    assert_eq!(stats.total_volume, 22_000_000); // 10M + 5M + 7M
-    assert!(stats.total_fees > 0); // Player 1 won
-    assert!(stats.reserve_balance > 0); // House has reserves
+    // Only player2's start_game increments total_games (players 1 and 3 were injected)
+    assert_eq!(stats.total_games, 1);
+    // Only player2's wager was recorded via start_game
+    assert_eq!(stats.total_volume, 5_000_000);
+    // Player 1's cash_out collected a fee
+    assert!(stats.total_fees > 0);
+    // Reserve must remain positive
+    assert!(stats.reserve_balance > 0);
 }
 
+// ── Edge cases ────────────────────────────────────────────────────────────────
+
+/// All stat fields must be non-negative after 10 game starts.
+///
+/// Note: `total_games` is `u64` so `>= 0` is always true; the meaningful
+/// check is that `total_volume`, `total_fees`, and `reserve_balance` (all
+/// `i128`) remain non-negative.  We also assert the exact `total_games` count.
 #[test]
 fn test_statistics_never_become_negative() {
     let (env, client, contract_id) = setup();
     fund(&env, &contract_id, 1_000_000_000_000);
-    
-    // Perform various operations
+
     for i in 0u8..10 {
         let player = Address::generate(&env);
         client.start_game(&player, &Side::Heads, &1_000_000, &make_commitment(&env, i + 1));
     }
-    
-    // Verify all statistics are non-negative
+
     let stats = load_stats(&env, &contract_id);
-    assert!(stats.total_games >= 0);
-    assert!(stats.total_volume >= 0);
-    assert!(stats.total_fees >= 0);
-    assert!(stats.reserve_balance >= 0);
+    assert_eq!(stats.total_games, 10);
+    assert!(stats.total_volume >= 0, "total_volume must be non-negative");
+    assert!(stats.total_fees >= 0, "total_fees must be non-negative");
+    assert!(stats.reserve_balance >= 0, "reserve_balance must be non-negative");
 }
 
+/// Verify that 100 sequential game starts accumulate stats correctly.
 #[test]
 fn test_statistics_with_large_number_of_games() {
     let (env, client, contract_id) = setup();
     fund(&env, &contract_id, 10_000_000_000_000);
-    
-    // Create 100 games
-    let mut total_wager = 0i128;
-    for i in 0u8..100 {
+
+    let wager = 1_000_000i128;
+    let n = 100u8;
+    for i in 0..n {
         let player = Address::generate(&env);
-        let wager = 1_000_000i128;
-        total_wager += wager;
         client.start_game(&player, &Side::Heads, &wager, &make_commitment(&env, i));
     }
-    
-    // Verify statistics
+
     let stats = load_stats(&env, &contract_id);
-    assert_eq!(stats.total_games, 100);
-    assert_eq!(stats.total_volume, total_wager);
+    assert_eq!(stats.total_games, n as u64);
+    assert_eq!(stats.total_volume, wager * n as i128);
+}
+
+/// Verify that `total_fees` accumulates correctly across all four streak tiers.
+#[test]
+fn test_fees_accumulate_across_all_streak_tiers() {
+    let (env, client, contract_id) = setup();
+    fund(&env, &contract_id, 1_000_000_000_000);
+
+    let wager = 10_000_000i128;
+    let fee_bps = 300u32;
+    let mut expected = 0i128;
+
+    for streak in 1u32..=4 {
+        let player = Address::generate(&env);
+        inject_game(&env, &contract_id, &player, GamePhase::Revealed, streak, wager);
+        let (_, fee, _) = calculate_payout_breakdown(wager, streak, fee_bps).unwrap();
+        expected += fee;
+        client.cash_out(&player);
+    }
+
+    assert_eq!(load_stats(&env, &contract_id).total_fees, expected);
+}
+
+/// Verify that `reserve_balance` is correctly decremented across multiple cash-outs.
+#[test]
+fn test_reserve_decrements_correctly_across_multiple_cash_outs() {
+    let (env, client, contract_id) = setup();
+    let initial = 1_000_000_000_000i128;
+    fund(&env, &contract_id, initial);
+
+    let wager = 5_000_000i128;
+    let mut total_gross = 0i128;
+
+    for streak in 1u32..=4 {
+        let player = Address::generate(&env);
+        inject_game(&env, &contract_id, &player, GamePhase::Revealed, streak, wager);
+        let (gross, _, _) = calculate_payout_breakdown(wager, streak, 300).unwrap();
+        total_gross += gross;
+        client.cash_out(&player);
+    }
+
+    assert_eq!(
+        load_stats(&env, &contract_id).reserve_balance,
+        initial - total_gross
+    );
 }


### PR DESCRIPTION
Closes #143

- Document stat semantics in module-level table (total_games, total_volume, total_fees, reserve_balance — update triggers, direction, invariants)
- Fix std::Vec usage in no_std crate (replaced with i128 accumulators)
- Fix test_concurrent_settlements_accumulate_fees logic bug: inject and cash_out the same player per iteration so expected_fees matches actual
- Fix test_statistics_never_become_negative: replace tautological u64>=0 check with exact total_games count + meaningful i128 non-negative asserts
- Fix test_statistics_consistency_with_mixed_operations: use inject_game for win paths to avoid seed-based outcome non-determinism
- Fix unused loop variable warnings (for _ in ... where i was unused)
- Add test_reserve_balance_unchanged_by_start_game: start_game only checks reserve, never decrements it
- Add test_fees_accumulate_across_all_streak_tiers: covers all 4 multiplier tiers (1.9x, 3.5x, 6.0x, 10.0x)
- Add test_reserve_decrements_correctly_across_multiple_cash_outs
- Property tests 29a-29f cover 100 cases each via proptest