### PR TITLE
feat: VRF integration, contract upgrade/versioning, and fraud detection

### DIFF
--- a/contract/src/fraud_detection_tests.rs
+++ b/contract/src/fraud_detection_tests.rs
@@ -1,0 +1,248 @@
+//! Tests for fraud detection and prevention system (issue #467).
+
+#[cfg(test)]
+mod fraud_detection_tests {
+    use crate::*;
+    use soroban_sdk::{testutils::{Address as _, Ledger}, Env};
+
+    fn setup() -> (Env, Address, CoinflipContractClient<'static>) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(CoinflipContract, ());
+        let client = CoinflipContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        let token = Address::generate(&env);
+        client.initialize(
+            &admin, &treasury, &token, &300, &1_000_000, &100_000_000,
+            &BytesN::from_array(&env, &[0u8; 32]),
+        );
+        (env, admin, client)
+    }
+
+    fn fund(env: &Env, contract_id: &Address, amount: i128) {
+        env.as_contract(contract_id, || {
+            let mut stats = CoinflipContract::load_stats(env);
+            stats.reserve_balance = amount;
+            CoinflipContract::save_stats(env, &stats);
+        });
+    }
+
+    fn unique_commitment(env: &Env, seed: u8) -> BytesN<32> {
+        let secret = Bytes::from_slice(env, &[seed; 32]);
+        env.crypto().sha256(&secret).into()
+    }
+
+    // ── Rate limiting ─────────────────────────────────────────────────────────
+
+    /// First 10 games in a window succeed; the 11th is rejected.
+    #[test]
+    fn test_rate_limit_blocks_11th_game() {
+        let (env, _admin, client) = setup();
+        let contract_id = env.register(CoinflipContract, ());
+        fund(&env, &contract_id, 100_000_000_000);
+
+        let player = Address::generate(&env);
+        // Start 10 games (each with a unique player to avoid ActiveGameExists).
+        for i in 0..10u8 {
+            let p = Address::generate(&env);
+            let commitment = unique_commitment(&env, i + 1);
+            let result = client.try_start_game(
+                &p, &Side::Heads, &1_000_000, &commitment,
+                &None, &BytesN::from_array(&env, &[0u8; 32]), &Address::generate(&env),
+            );
+            // May fail for other reasons (reserves, token whitelist) — we only care
+            // that it does NOT fail with ContractPaused from rate limiting.
+            if let Err(Ok(e)) = result {
+                assert_ne!(e, Error::ContractPaused, "game {} should not be rate-limited", i);
+            }
+        }
+
+        // The rate-limit check is per-player, so test with a single player hitting 11.
+        // Reset: use a fresh player and advance ledger to clear any window.
+        let p = Address::generate(&env);
+        // Manually set rate limit state to simulate 10 games already in window.
+        env.as_contract(&contract_id, || {
+            let state = PlayerRateLimit {
+                window_start: env.ledger().sequence(),
+                games_in_window: RATE_LIMIT_MAX_GAMES,
+            };
+            env.storage().persistent().set(&StorageKey::PlayerRateLimit(p.clone()), &state);
+        });
+
+        let commitment = unique_commitment(&env, 99);
+        let result = client.try_start_game(
+            &p, &Side::Heads, &1_000_000, &commitment,
+            &None, &BytesN::from_array(&env, &[0u8; 32]), &Address::generate(&env),
+        );
+        assert_eq!(result, Err(Ok(Error::ContractPaused)), "11th game must be rate-limited");
+    }
+
+    /// Rate limit window resets after RATE_LIMIT_WINDOW_LEDGERS ledgers.
+    #[test]
+    fn test_rate_limit_window_resets() {
+        let (env, _admin, client) = setup();
+        let contract_id = env.register(CoinflipContract, ());
+
+        let p = Address::generate(&env);
+        // Set state: window full, but started long ago.
+        env.as_contract(&contract_id, || {
+            let state = PlayerRateLimit {
+                window_start: 0, // very old
+                games_in_window: RATE_LIMIT_MAX_GAMES + 5,
+            };
+            env.storage().persistent().set(&StorageKey::PlayerRateLimit(p.clone()), &state);
+        });
+        // Advance ledger past the window.
+        env.ledger().with_mut(|l| l.sequence_number = RATE_LIMIT_WINDOW_LEDGERS + 10);
+
+        // check_rate_limit should reset and allow the game.
+        env.as_contract(&contract_id, || {
+            let result = CoinflipContract::check_rate_limit(&env, &p);
+            assert!(result.is_ok(), "window should have reset");
+        });
+    }
+
+    // ── Fraud flag ────────────────────────────────────────────────────────────
+
+    /// set_fraud_flag stores a FraudFlag retrievable via get_fraud_flag.
+    #[test]
+    fn test_fraud_flag_stored_and_retrieved() {
+        let (env, _admin, client) = setup();
+        let contract_id = env.register(CoinflipContract, ());
+        let p = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            CoinflipContract::set_fraud_flag(&env, &p, symbol_short!("rate_limit"));
+        });
+
+        let flag = client.get_fraud_flag(&p);
+        assert!(flag.is_some());
+        assert_eq!(flag.unwrap().reason, symbol_short!("rate_limit"));
+    }
+
+    /// get_fraud_flag returns None when no flag is set.
+    #[test]
+    fn test_get_fraud_flag_none_when_clean() {
+        let (env, _admin, client) = setup();
+        let p = Address::generate(&env);
+        assert!(client.get_fraud_flag(&p).is_none());
+    }
+
+    /// clear_fraud_flag removes the flag; admin only.
+    #[test]
+    fn test_clear_fraud_flag_admin_only() {
+        let (env, admin, client) = setup();
+        let contract_id = env.register(CoinflipContract, ());
+        let p = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            CoinflipContract::set_fraud_flag(&env, &p, symbol_short!("win_streak"));
+        });
+        assert!(client.get_fraud_flag(&p).is_some());
+
+        client.clear_fraud_flag(&admin, &p);
+        assert!(client.get_fraud_flag(&p).is_none());
+    }
+
+    /// clear_fraud_flag is rejected for non-admin.
+    #[test]
+    fn test_clear_fraud_flag_unauthorized() {
+        let (env, _admin, client) = setup();
+        let attacker = Address::generate(&env);
+        let p = Address::generate(&env);
+        assert_eq!(
+            client.try_clear_fraud_flag(&attacker, &p),
+            Err(Ok(Error::Unauthorized))
+        );
+    }
+
+    // ── Anomaly detection ─────────────────────────────────────────────────────
+
+    /// check_anomaly flags a player with a win streak >= threshold.
+    #[test]
+    fn test_anomaly_win_streak_flagged() {
+        let (env, _admin, _client) = setup();
+        let contract_id = env.register(CoinflipContract, ());
+        let p = Address::generate(&env);
+
+        let stats = PlayerStats {
+            games_played: 8,
+            wins: 8,
+            losses: 0,
+            max_streak: ANOMALY_WIN_STREAK_THRESHOLD,
+            current_streak: ANOMALY_WIN_STREAK_THRESHOLD,
+            total_wagered: 0,
+            net_winnings: 0,
+        };
+
+        env.as_contract(&contract_id, || {
+            CoinflipContract::check_anomaly(&env, &p, &stats);
+            let flag = env.storage().persistent()
+                .get::<StorageKey, FraudFlag>(&StorageKey::FraudFlag(p.clone()));
+            assert!(flag.is_some());
+            assert_eq!(flag.unwrap().reason, symbol_short!("win_streak"));
+        });
+    }
+
+    /// check_anomaly flags a player with many losses and no wins.
+    #[test]
+    fn test_anomaly_loss_streak_flagged() {
+        let (env, _admin, _client) = setup();
+        let contract_id = env.register(CoinflipContract, ());
+        let p = Address::generate(&env);
+
+        let stats = PlayerStats {
+            games_played: ANOMALY_LOSS_STREAK_THRESHOLD as u64,
+            wins: 0,
+            losses: ANOMALY_LOSS_STREAK_THRESHOLD as u64,
+            max_streak: 0,
+            current_streak: 0,
+            total_wagered: 0,
+            net_winnings: 0,
+        };
+
+        env.as_contract(&contract_id, || {
+            CoinflipContract::check_anomaly(&env, &p, &stats);
+            let flag = env.storage().persistent()
+                .get::<StorageKey, FraudFlag>(&StorageKey::FraudFlag(p.clone()));
+            assert!(flag.is_some());
+            assert_eq!(flag.unwrap().reason, symbol_short!("loss_streak"));
+        });
+    }
+
+    /// Normal player stats produce no fraud flag.
+    #[test]
+    fn test_anomaly_normal_player_no_flag() {
+        let (env, _admin, _client) = setup();
+        let contract_id = env.register(CoinflipContract, ());
+        let p = Address::generate(&env);
+
+        let stats = PlayerStats {
+            games_played: 10,
+            wins: 5,
+            losses: 5,
+            max_streak: 3,
+            current_streak: 1,
+            total_wagered: 0,
+            net_winnings: 0,
+        };
+
+        env.as_contract(&contract_id, || {
+            CoinflipContract::check_anomaly(&env, &p, &stats);
+            let flag = env.storage().persistent()
+                .get::<StorageKey, FraudFlag>(&StorageKey::FraudFlag(p.clone()));
+            assert!(flag.is_none());
+        });
+    }
+
+    // ── Constants ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_fraud_constants() {
+        assert_eq!(RATE_LIMIT_MAX_GAMES, 10);
+        assert_eq!(RATE_LIMIT_WINDOW_LEDGERS, 60);
+        assert_eq!(ANOMALY_WIN_STREAK_THRESHOLD, 8);
+        assert_eq!(ANOMALY_LOSS_STREAK_THRESHOLD, 20);
+    }
+}

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -724,6 +724,12 @@ pub enum StorageKey {
     MpcSession(u64),
     /// MPC session counter (u64) — monotonically increasing session id.
     MpcSessionCount,
+    /// Config version history ([`Vec<ConfigVersion>`]).
+    ConfigHistory,
+    /// Per-player rate-limit state ([`PlayerRateLimit`]).
+    PlayerRateLimit(Address),
+    /// Per-player fraud/anomaly flag ([`FraudFlag`]).
+    FraudFlag(Address),
 }
 
 /// Aggregate pause statistics for a single [`PausableOperation`].
@@ -746,6 +752,78 @@ pub struct PauseAnalytics {
     pub last_paused_ledger: u32,
 }
 
+// ── Config versioning constants ───────────────────────────────────────────────
+
+/// Maximum number of config history snapshots retained. Oldest entry is evicted
+/// when this cap is exceeded.
+pub const MAX_CONFIG_HISTORY: u32 = 50;
+
+/// Maximum byte length for a config version label.
+pub const MAX_LABEL_BYTES: u32 = 64;
+
+/// An immutable snapshot of [`ContractConfig`] captured after every admin write.
+///
+/// Stored in a `Vec<ConfigVersion>` under [`StorageKey::ConfigHistory`].
+/// Enables rollback to any prior configuration and full audit trail.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ConfigVersion {
+    /// Monotonically increasing version counter (starts at 1 on `initialize`).
+    pub version_number: u32,
+    /// Ledger sequence at which this version was written.
+    pub ledger: u32,
+    /// Optional human-readable label (max 64 bytes).
+    pub label: Bytes,
+    /// Full config snapshot at this version.
+    pub config: ContractConfig,
+}
+
+/// A single field difference between two [`ConfigVersion`] snapshots.
+/// Returned by [`CoinflipContract::compare_config_versions`].
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ConfigDiffEntry {
+    /// Name of the differing field (e.g. `Symbol("fee_bps")`).
+    pub field: Symbol,
+    /// XDR-encoded value from version A.
+    pub value_a: Bytes,
+    /// XDR-encoded value from version B.
+    pub value_b: Bytes,
+}
+
+// ── Fraud detection constants & types ────────────────────────────────────────
+
+/// Maximum games a player may start within a 60-ledger (~5 min) window.
+pub const RATE_LIMIT_MAX_GAMES: u32 = 10;
+/// Sliding window size in ledgers for rate limiting.
+pub const RATE_LIMIT_WINDOW_LEDGERS: u32 = 60;
+/// Consecutive-loss threshold that triggers an anomaly flag.
+pub const ANOMALY_LOSS_STREAK_THRESHOLD: u32 = 20;
+/// Consecutive-win threshold that triggers an anomaly flag (unusually lucky).
+pub const ANOMALY_WIN_STREAK_THRESHOLD: u32 = 8;
+
+/// Per-player rate-limit state stored under [`StorageKey::PlayerRateLimit`].
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PlayerRateLimit {
+    /// Ledger sequence of the first game in the current window.
+    pub window_start: u32,
+    /// Number of games started in the current window.
+    pub games_in_window: u32,
+}
+
+/// Fraud/anomaly flag stored under [`StorageKey::FraudFlag`].
+///
+/// Set when a player triggers a rate-limit or anomaly threshold.
+/// Admin can query and clear flags via `get_fraud_flag` / `clear_fraud_flag`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FraudFlag {
+    /// Ledger at which the flag was set.
+    pub flagged_at: u32,
+    /// Short reason code (e.g. `Symbol("rate_limit")`, `Symbol("loss_streak")`).
+    pub reason: Symbol,
+}
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -2600,6 +2678,9 @@ impl CoinflipContract {
     ) -> Result<(), Error> {
         player.require_auth();
 
+        // Fraud guard: enforce per-player rate limit.
+        Self::check_rate_limit(&env, &player)?;
+
         let config = Self::load_config(&env);
 
         // Guard 1: contract must not be paused or in shutdown mode
@@ -2943,6 +3024,7 @@ impl CoinflipContract {
                 player_stats.max_streak = game.streak;
             }
             Self::save_player_stats(&env, &player, &player_stats);
+            Self::check_anomaly(&env, &player, &player_stats);
             
             Ok(true)
         } else {
@@ -5661,6 +5743,80 @@ impl CoinflipContract {
 
         Ok(final_results)
     }
+
+    // ── Fraud detection helpers ───────────────────────────────────────────────
+
+    /// Enforce per-player rate limiting: max [`RATE_LIMIT_MAX_GAMES`] games per
+    /// [`RATE_LIMIT_WINDOW_LEDGERS`] ledgers.  Sets a [`FraudFlag`] and returns
+    /// `Err(Error::ContractPaused)` when the limit is exceeded.
+    fn check_rate_limit(env: &Env, player: &Address) -> Result<(), Error> {
+        let key = StorageKey::PlayerRateLimit(player.clone());
+        let current_ledger = env.ledger().sequence();
+        let mut state: PlayerRateLimit = env.storage().persistent()
+            .get(&key)
+            .unwrap_or(PlayerRateLimit { window_start: current_ledger, games_in_window: 0 });
+
+        // Reset window if expired.
+        if current_ledger.saturating_sub(state.window_start) >= RATE_LIMIT_WINDOW_LEDGERS {
+            state.window_start = current_ledger;
+            state.games_in_window = 0;
+        }
+
+        state.games_in_window = state.games_in_window.saturating_add(1);
+        env.storage().persistent().set(&key, &state);
+        env.storage().persistent().extend_ttl(&key, TTL_THRESHOLD, TTL_EXTEND_TO);
+
+        if state.games_in_window > RATE_LIMIT_MAX_GAMES {
+            Self::set_fraud_flag(env, player, symbol_short!("rate_limit"));
+            return Err(Error::ContractPaused);
+        }
+        Ok(())
+    }
+
+    /// Check player stats for anomalous patterns and set a [`FraudFlag`] if found.
+    /// Called after every game outcome.
+    fn check_anomaly(env: &Env, player: &Address, stats: &PlayerStats) {
+        if stats.current_streak >= ANOMALY_WIN_STREAK_THRESHOLD {
+            Self::set_fraud_flag(env, player, symbol_short!("win_streak"));
+        }
+        // Detect unusual loss pattern: losses >> wins by large margin.
+        if stats.losses > 0 && stats.wins == 0 && stats.losses >= ANOMALY_LOSS_STREAK_THRESHOLD as u64 {
+            Self::set_fraud_flag(env, player, symbol_short!("loss_streak"));
+        }
+    }
+
+    /// Persist a [`FraudFlag`] for `player` and emit an admin alert event.
+    fn set_fraud_flag(env: &Env, player: &Address, reason: Symbol) {
+        let flag = FraudFlag { flagged_at: env.ledger().sequence(), reason: reason.clone() };
+        env.storage().persistent().set(&StorageKey::FraudFlag(player.clone()), &flag);
+        env.storage().persistent().extend_ttl(
+            &StorageKey::FraudFlag(player.clone()), TTL_THRESHOLD, TTL_EXTEND_TO,
+        );
+        // Emit alert event for off-chain monitoring.
+        env.events().publish(
+            (symbol_short!("tossd"), symbol_short!("fraud_flag")),
+            (player.clone(), reason),
+        );
+    }
+
+    // ── Fraud detection admin entry points ────────────────────────────────────
+
+    /// Return the [`FraudFlag`] for `player`, or `None` if no flag is set.
+    /// No auth required — readable by anyone for transparency.
+    pub fn get_fraud_flag(env: Env, player: Address) -> Option<FraudFlag> {
+        env.storage().persistent().get(&StorageKey::FraudFlag(player))
+    }
+
+    /// Clear the fraud flag for `player`. Admin only.
+    pub fn clear_fraud_flag(env: Env, admin: Address, player: Address) -> Result<(), Error> {
+        admin.require_auth();
+        let config = Self::load_config(&env);
+        if admin != config.admin {
+            return Err(Error::Unauthorized);
+        }
+        env.storage().persistent().remove(&StorageKey::FraudFlag(player));
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -5717,6 +5873,9 @@ mod observability_tests;
 
 #[cfg(test)]
 mod upgrade_migration_tests;
+
+#[cfg(test)]
+mod fraud_detection_tests;
 
 #[cfg(test)]
 mod security_validation_tests;

--- a/contract/src/upgrade_migration_tests.rs
+++ b/contract/src/upgrade_migration_tests.rs
@@ -1,214 +1,157 @@
+//! Tests for contract upgrade, versioning, and rollback (issue #468).
+
 #[cfg(test)]
 mod upgrade_migration_tests {
     use crate::*;
-    use soroban_sdk::{testutils::*, Env};
+    use soroban_sdk::{testutils::Address as _, Env};
 
-    /// Test state migration from v1 to v2 contract
-    #[test]
-    fn test_v1_to_v2_state_migration() {
+    fn setup() -> (Env, CoinflipContractClient<'static>, Address, Address) {
         let env = Env::default();
         env.mock_all_auths();
-
-        let admin = Address::random(&env);
-        let player = Address::random(&env);
-        let token = create_stellar_asset(&env, &admin);
-
-        // Initialize v1 contract state
-        initialize_contract(&env, &admin, &token, &admin);
-        fund_player(&env, &player, &token, 10_000_0000000);
-
-        // Simulate v1 game state
-        let v1_game_state = GameState {
-            player: player.clone(),
-            wager: 100_0000000i128,
-            phase: GamePhase::Completed,
-            commitment: BytesN::<32>::random(&env),
-            contract_random: BytesN::<32>::random(&env),
-            outcome: Side::Heads,
-            payout: 250_0000000i128,
-            streak: 1u32,
-            last_reveal_ledger: 100u32,
-        };
-
-        // Verify v1 state can be read
-        assert_eq!(v1_game_state.player, player);
-        assert_eq!(v1_game_state.wager, 100_0000000i128);
+        let contract_id = env.register(CoinflipContract, ());
+        let client = CoinflipContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        let token = Address::generate(&env);
+        client.initialize(
+            &admin, &treasury, &token, &300, &1_000_000, &100_000_000,
+            &BytesN::from_array(&env, &[0u8; 32]),
+        );
+        (env, client, contract_id, admin)
     }
 
-    /// Test backward compatibility with v1 data structures
+    /// initialize creates version 1 with the genesis config.
     #[test]
-    fn test_backward_compatibility_v1_data() {
-        let env = Env::default();
-        env.mock_all_auths();
-
-        let admin = Address::random(&env);
-        let token = create_stellar_asset(&env, &admin);
-
-        initialize_contract(&env, &admin, &token, &admin);
-
-        // Verify v1 config structure is compatible
-        let config = ContractConfig {
-            min_wager: 1_0000000i128,
-            max_wager: 1_000_0000000i128,
-            fee_percentage: 500u32,
-            paused: false,
-        };
-
-        assert_eq!(config.min_wager, 1_0000000i128);
-        assert_eq!(config.max_wager, 1_000_0000000i128);
-        assert_eq!(config.fee_percentage, 500u32);
+    fn test_initialize_creates_version_1() {
+        let (_env, client, _cid, _admin) = setup();
+        let history = client.list_config_versions();
+        assert_eq!(history.len(), 1);
+        let v1 = history.get(0).unwrap();
+        assert_eq!(v1.version_number, 1);
+        assert_eq!(v1.config.fee_bps, 300);
     }
 
-    /// Test data integrity after upgrade
+    /// Each admin write appends a new version.
     #[test]
-    fn test_data_integrity_post_upgrade() {
-        let env = Env::default();
-        env.mock_all_auths();
-
-        let admin = Address::random(&env);
-        let player = Address::random(&env);
-        let token = create_stellar_asset(&env, &admin);
-
-        initialize_contract(&env, &admin, &token, &admin);
-        fund_player(&env, &player, &token, 10_000_0000000);
-
-        // Create v1 game state
-        let original_wager = 100_0000000i128;
-        let original_payout = 250_0000000i128;
-
-        // Simulate upgrade - verify data is preserved
-        assert_eq!(original_wager, 100_0000000i128);
-        assert_eq!(original_payout, 250_0000000i128);
+    fn test_each_write_increments_version() {
+        let (_env, client, _cid, admin) = setup();
+        client.set_fee(&admin, &350, &None);
+        client.set_fee(&admin, &400, &None);
+        let history = client.list_config_versions();
+        assert_eq!(history.len(), 3);
+        assert_eq!(history.get(2).unwrap().version_number, 3);
     }
 
-    /// Test that v2 features don't break v1 games
+    /// get_config_version returns the correct snapshot.
     #[test]
-    fn test_v2_features_backward_compatible() {
-        let env = Env::default();
-        env.mock_all_auths();
-
-        let admin = Address::random(&env);
-        let player = Address::random(&env);
-        let token = create_stellar_asset(&env, &admin);
-
-        initialize_contract(&env, &admin, &token, &admin);
-        fund_player(&env, &player, &token, 10_000_0000000);
-
-        // Verify v1 game can still be played with v2 contract
-        let commitment = BytesN::<32>::random(&env);
-        let wager = 100_0000000i128;
-
-        // V1 game should work unchanged
-        assert!(wager > 0);
-        assert!(commitment.len() == 32);
+    fn test_get_config_version_returns_snapshot() {
+        let (_env, client, _cid, admin) = setup();
+        client.set_fee(&admin, &400, &None);
+        let v1 = client.get_config_version(&1).unwrap();
+        assert_eq!(v1.config.fee_bps, 300);
+        let v2 = client.get_config_version(&2).unwrap();
+        assert_eq!(v2.config.fee_bps, 400);
     }
 
-    /// Test rollback simulation - verify v2 can revert to v1 state
+    /// get_config_version returns VersionNotFound for unknown version.
     #[test]
-    fn test_rollback_to_v1_state() {
-        let env = Env::default();
-        env.mock_all_auths();
-
-        let admin = Address::random(&env);
-        let player = Address::random(&env);
-        let token = create_stellar_asset(&env, &admin);
-
-        initialize_contract(&env, &admin, &token, &admin);
-        fund_player(&env, &player, &token, 10_000_0000000);
-
-        // Create v2 state
-        let v2_state = GameState {
-            player: player.clone(),
-            wager: 100_0000000i128,
-            phase: GamePhase::Completed,
-            commitment: BytesN::<32>::random(&env),
-            contract_random: BytesN::<32>::random(&env),
-            outcome: Side::Heads,
-            payout: 250_0000000i128,
-            streak: 1u32,
-            last_reveal_ledger: 100u32,
-        };
-
-        // Verify rollback preserves essential fields
-        assert_eq!(v2_state.player, player);
-        assert_eq!(v2_state.wager, 100_0000000i128);
-        assert_eq!(v2_state.payout, 250_0000000i128);
+    fn test_get_version_not_found() {
+        let (_env, client, _cid, _admin) = setup();
+        assert_eq!(
+            client.try_get_config_version(&999),
+            Err(Ok(Error::VersionNotFound))
+        );
     }
 
-    /// Test config migration preserves all settings
+    /// rollback restores the target config and appends an audit snapshot.
     #[test]
-    fn test_config_migration_completeness() {
-        let env = Env::default();
-        env.mock_all_auths();
-
-        let admin = Address::random(&env);
-        let token = create_stellar_asset(&env, &admin);
-
-        initialize_contract(&env, &admin, &token, &admin);
-
-        let config = ContractConfig {
-            min_wager: 1_0000000i128,
-            max_wager: 1_000_0000000i128,
-            fee_percentage: 500u32,
-            paused: false,
-        };
-
-        // Verify all config fields are preserved
-        assert_eq!(config.min_wager, 1_0000000i128);
-        assert_eq!(config.max_wager, 1_000_0000000i128);
-        assert_eq!(config.fee_percentage, 500u32);
-        assert_eq!(config.paused, false);
+    fn test_rollback_restores_config() {
+        let (_env, client, _cid, admin) = setup();
+        client.set_fee(&admin, &400, &None);
+        client.rollback_config(&admin, &1);
+        // Version 3 is the rollback audit snapshot — it should have fee_bps = 300.
+        let v3 = client.get_config_version(&3).unwrap();
+        assert_eq!(v3.config.fee_bps, 300);
     }
 
-    /// Test stats migration preserves historical data
+    /// rollback is rejected for non-admin callers.
     #[test]
-    fn test_stats_migration_preserves_history() {
-        let env = Env::default();
-        env.mock_all_auths();
-
-        let admin = Address::random(&env);
-        let token = create_stellar_asset(&env, &admin);
-
-        initialize_contract(&env, &admin, &token, &admin);
-
-        let stats = ContractStats {
-            total_games: 100u64,
-            total_wagers: 10_000_0000000i128,
-            total_payouts: 12_500_0000000i128,
-            total_fees: 500_0000000i128,
-        };
-
-        // Verify stats are preserved
-        assert_eq!(stats.total_games, 100u64);
-        assert_eq!(stats.total_wagers, 10_000_0000000i128);
-        assert_eq!(stats.total_payouts, 12_500_0000000i128);
+    fn test_rollback_unauthorized() {
+        let (env, client, _cid, _admin) = setup();
+        let attacker = Address::generate(&env);
+        assert_eq!(
+            client.try_rollback_config(&attacker, &1),
+            Err(Ok(Error::Unauthorized))
+        );
     }
 
-    /// Test that error codes remain stable across upgrade
+    /// rollback to missing version returns VersionNotFound.
     #[test]
-    fn test_error_code_stability_across_upgrade() {
-        // Verify error codes don't change
-        assert_eq!(error_codes::WAGER_BELOW_MINIMUM, 1u32);
-        assert_eq!(error_codes::WAGER_ABOVE_MAXIMUM, 2u32);
-        assert_eq!(error_codes::ACTIVE_GAME_EXISTS, 3u32);
-        assert_eq!(error_codes::INSUFFICIENT_RESERVES, 4u32);
-        assert_eq!(error_codes::CONTRACT_PAUSED, 5u32);
-        assert_eq!(error_codes::NO_ACTIVE_GAME, 10u32);
-        assert_eq!(error_codes::INVALID_PHASE, 11u32);
-        assert_eq!(error_codes::COMMITMENT_MISMATCH, 12u32);
-        assert_eq!(error_codes::UNAUTHORIZED, 30u32);
+    fn test_rollback_version_not_found() {
+        let (_env, client, _cid, admin) = setup();
+        assert_eq!(
+            client.try_rollback_config(&admin, &999),
+            Err(Ok(Error::VersionNotFound))
+        );
     }
 
-    // Helper functions
-    fn create_stellar_asset(env: &Env, admin: &Address) -> Address {
-        Address::random(env)
+    /// compare_config_versions returns empty diff for identical versions.
+    #[test]
+    fn test_compare_identical_versions_empty_diff() {
+        let (_env, client, _cid, _admin) = setup();
+        let diff = client.compare_config_versions(&1, &1).unwrap();
+        assert_eq!(diff.len(), 0);
     }
 
-    fn initialize_contract(env: &Env, admin: &Address, token: &Address, treasury: &Address) {
-        // Minimal initialization
+    /// compare_config_versions detects changed fee_bps.
+    #[test]
+    fn test_compare_versions_detects_diff() {
+        let (env, client, _cid, admin) = setup();
+        client.set_fee(&admin, &400, &None);
+        let diff = client.compare_config_versions(&1, &2).unwrap();
+        assert_eq!(diff.len(), 1);
+        assert_eq!(diff.get(0).unwrap().field, Symbol::new(&env, "fee_bps"));
     }
 
-    fn fund_player(env: &Env, player: &Address, token: &Address, amount: i128) {
-        // Minimal funding
+    /// Label too long is rejected; config unchanged.
+    #[test]
+    fn test_label_too_long_rejected() {
+        let (env, client, _cid, admin) = setup();
+        let long_label = Bytes::from_slice(&env, &[b'x'; 65]);
+        assert_eq!(
+            client.try_set_fee(&admin, &350, &Some(long_label)),
+            Err(Ok(Error::InvalidVersionLabel))
+        );
+        // Still only version 1.
+        assert_eq!(client.list_config_versions().len(), 1);
+    }
+
+    /// History is capped at MAX_CONFIG_HISTORY; oldest entry is evicted.
+    #[test]
+    fn test_history_cap_evicts_oldest() {
+        let (env, client, _cid, admin) = setup();
+        for i in 0..50u32 {
+            let label = Bytes::from_slice(&env, format!("v{}", i + 2).as_bytes());
+            client.set_fee(&admin, &(300 + (i % 200)), &Some(label));
+        }
+        let history = client.list_config_versions();
+        assert_eq!(history.len(), 50);
+        // Version 1 evicted; first remaining is version 2.
+        assert_eq!(history.get(0).unwrap().version_number, 2);
+    }
+
+    /// Error codes are stable (backward compatibility guarantee).
+    #[test]
+    fn test_error_code_stability() {
+        assert_eq!(error_codes::WAGER_BELOW_MINIMUM, 1);
+        assert_eq!(error_codes::WAGER_ABOVE_MAXIMUM, 2);
+        assert_eq!(error_codes::ACTIVE_GAME_EXISTS, 3);
+        assert_eq!(error_codes::INSUFFICIENT_RESERVES, 4);
+        assert_eq!(error_codes::CONTRACT_PAUSED, 5);
+        assert_eq!(error_codes::NO_ACTIVE_GAME, 10);
+        assert_eq!(error_codes::COMMITMENT_MISMATCH, 12);
+        assert_eq!(error_codes::UNAUTHORIZED, 30);
+        assert_eq!(error_codes::ALREADY_INITIALIZED, 51);
+        assert_eq!(error_codes::VERSION_NOT_FOUND, 36);
     }
 }

--- a/contract/src/vrf_tests.rs
+++ b/contract/src/vrf_tests.rs
@@ -184,3 +184,16 @@ fn test_vrf_output_deterministic() {
     let out2 = env.crypto().sha256(&proof_bytes).to_array();
     assert_eq!(out1, out2);
 }
+
+/// verify_vrf_proof panics (aborts tx) when pk is non-zero and proof is invalid.
+#[test]
+#[should_panic]
+fn test_verify_vrf_proof_invalid_proof_panics() {
+    let env = Env::default();
+    // Non-zero pk — any 32-byte value that is not all-zero triggers real verification.
+    let pk    = BytesN::from_array(&env, &[0xABu8; 32]);
+    let input = BytesN::from_array(&env, &[1u8; 32]);
+    // All-zero proof is not a valid Ed25519 signature for this pk/input pair.
+    let proof = BytesN::from_array(&env, &[0u8; 64]);
+    verify_vrf_proof(&env, &pk, &input, &proof);
+}

--- a/docs/FRAUD_DETECTION.md
+++ b/docs/FRAUD_DETECTION.md
@@ -1,0 +1,104 @@
+# Fraud Detection and Prevention System
+
+The contract implements three complementary fraud-prevention layers:
+rate limiting, anomaly detection, and admin alerts via on-chain events.
+
+## Rate limiting
+
+Every `start_game` call passes through `check_rate_limit` before any other
+logic runs.
+
+| Constant                    | Value | Meaning                              |
+|-----------------------------|-------|--------------------------------------|
+| `RATE_LIMIT_MAX_GAMES`      | 10    | Max games per window                 |
+| `RATE_LIMIT_WINDOW_LEDGERS` | 60    | Sliding window (~5 minutes at 5 s/ledger) |
+
+**Mechanism:**
+1. Load `PlayerRateLimit` from `StorageKey::PlayerRateLimit(player)`.
+2. If the window has expired (`current_ledger - window_start ≥ 60`), reset it.
+3. Increment `games_in_window`.
+4. If `games_in_window > 10`, call `set_fraud_flag(player, "rate_limit")` and
+   return `Err(Error::ContractPaused)` — the game is rejected.
+
+State is stored per-player in persistent storage and extended on every access.
+
+## Anomaly detection
+
+`check_anomaly` is called after every game outcome (win or loss) and inspects
+the player's cumulative `PlayerStats`.
+
+| Constant                        | Value | Trigger                                  |
+|---------------------------------|-------|------------------------------------------|
+| `ANOMALY_WIN_STREAK_THRESHOLD`  | 8     | Current win streak ≥ 8 consecutive wins  |
+| `ANOMALY_LOSS_STREAK_THRESHOLD` | 20    | 20+ losses with zero wins                |
+
+Anomaly detection **does not block** the game — it only sets a flag for admin
+review. This avoids false positives disrupting legitimate players.
+
+## Admin alert system
+
+`set_fraud_flag` persists a `FraudFlag` and emits an on-chain event:
+
+```
+event topic:  (Symbol("tossd"), Symbol("fraud_flag"))
+event data:   (player: Address, reason: Symbol)
+```
+
+Reason codes:
+- `Symbol("rate_limit")` — rate limit exceeded
+- `Symbol("win_streak")` — unusually long win streak
+- `Symbol("loss_streak")` — unusually long loss streak with no wins
+
+Off-chain monitoring services can subscribe to these events and trigger
+manual review workflows.
+
+## Admin entry points
+
+### `get_fraud_flag(player) → Option<FraudFlag>`
+
+Returns the current flag for `player`, or `None`. No auth required — readable
+by anyone for transparency.
+
+```rust
+let flag = client.get_fraud_flag(&player);
+// FraudFlag { flagged_at: 12345, reason: Symbol("rate_limit") }
+```
+
+### `clear_fraud_flag(admin, player) → Result<(), Error>`
+
+Clears the flag after admin review. Requires admin auth.
+
+```rust
+client.clear_fraud_flag(&admin, &player);
+```
+
+## FraudFlag struct
+
+| Field        | Type     | Description                          |
+|--------------|----------|--------------------------------------|
+| `flagged_at` | `u32`    | Ledger sequence when flag was set    |
+| `reason`     | `Symbol` | Short reason code (see above)        |
+
+## Privacy considerations
+
+- Flags are keyed by player address, which is already public on Stellar.
+- No personal data beyond the on-chain address is stored.
+- Flags can be cleared by the admin after review.
+- Rate-limit state (`PlayerRateLimit`) stores only ledger sequence and a count,
+  not game content.
+
+## Relevant code
+
+| Symbol                      | Location   | Description                          |
+|-----------------------------|------------|--------------------------------------|
+| `check_rate_limit`          | `lib.rs`   | Rate limit enforcement (called in `start_game`) |
+| `check_anomaly`             | `lib.rs`   | Anomaly detection (called after reveal) |
+| `set_fraud_flag`            | `lib.rs`   | Flag + event emission                |
+| `get_fraud_flag`            | `lib.rs`   | Admin query                          |
+| `clear_fraud_flag`          | `lib.rs`   | Admin clear                          |
+| `PlayerRateLimit`           | `lib.rs`   | Per-player rate-limit state          |
+| `FraudFlag`                 | `lib.rs`   | Fraud flag struct                    |
+| `RATE_LIMIT_MAX_GAMES`      | `lib.rs`   | 10 games per window                  |
+| `RATE_LIMIT_WINDOW_LEDGERS` | `lib.rs`   | 60-ledger window                     |
+| `ANOMALY_WIN_STREAK_THRESHOLD` | `lib.rs` | 8 consecutive wins                  |
+| `ANOMALY_LOSS_STREAK_THRESHOLD`| `lib.rs` | 20 losses with no wins              |

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -1,0 +1,87 @@
+# Contract Upgrade and Versioning System
+
+Every admin configuration change is automatically snapshotted into an immutable
+history, enabling full audit trails, version comparison, and one-step rollback.
+
+## Version tracking
+
+A `ConfigVersion` snapshot is appended to `StorageKey::ConfigHistory` after
+every successful call to `set_fee`, `set_treasury`, `set_wager_limits`,
+`set_paused`, `set_multipliers`, or `update_config`.
+
+```
+initialize  →  version 1
+set_fee     →  version 2
+set_paused  →  version 3
+rollback(1) →  version 4  (audit snapshot of the restored config)
+```
+
+History is capped at **50 entries** (`MAX_CONFIG_HISTORY`). When the cap is
+reached the oldest entry is evicted (FIFO).
+
+### ConfigVersion fields
+
+| Field            | Type            | Description                              |
+|------------------|-----------------|------------------------------------------|
+| `version_number` | `u32`           | Monotonically increasing (starts at 1)   |
+| `ledger`         | `u32`           | Ledger sequence at write time            |
+| `label`          | `Bytes` (≤64 B) | Optional human-readable change note      |
+| `config`         | `ContractConfig`| Full config snapshot                     |
+
+## Upgrade mechanism
+
+Soroban contracts are upgraded by deploying a new WASM binary via
+`env.deployer().update_current_contract_wasm(new_wasm_hash)`. The config
+versioning system ensures the live configuration is preserved across WASM
+upgrades because it is stored in persistent storage, not in the binary.
+
+**Migration helpers:**
+- `list_config_versions` — enumerate all snapshots
+- `get_config_version(n)` — retrieve a specific version
+- `compare_config_versions(a, b)` — diff two versions field-by-field
+
+## Rollback
+
+```rust
+// Revert live config to version 1
+client.rollback_config(&admin, &1);
+```
+
+`rollback_config`:
+1. Requires admin auth.
+2. Looks up the target version in history (`Error::VersionNotFound` if missing).
+3. Writes the target config atomically to `StorageKey::Config`.
+4. Appends a new audit snapshot labelled `"rollback to vN"`.
+5. Emits a `(tossd, config_rollback)` event with `(target_version, new_version)`.
+
+Rollback is **non-destructive** — the history is never deleted, so you can
+roll forward again by rolling back to a later version.
+
+## Label validation
+
+Labels must be ≤ 64 bytes (`MAX_LABEL_BYTES`). Passing a longer label returns
+`Error::InvalidVersionLabel` and leaves the config unchanged.
+
+## Backward compatibility
+
+- Error codes are stable across upgrades (see `error_codes` module).
+- In-flight games snapshot `fee_bps` and `multipliers` at `start_game` time,
+  so admin changes never retroactively alter active game payouts.
+- `oracle_vrf_pk = [0u8; 32]` disables VRF verification for deployments that
+  do not use an oracle.
+
+## Relevant code
+
+| Symbol                    | Location              | Description                        |
+|---------------------------|-----------------------|------------------------------------|
+| `ConfigVersion`           | `lib.rs`              | Snapshot struct                    |
+| `ConfigDiffEntry`         | `lib.rs`              | Field diff entry                   |
+| `MAX_CONFIG_HISTORY`      | `lib.rs`              | History cap (50)                   |
+| `MAX_LABEL_BYTES`         | `lib.rs`              | Label length limit (64)            |
+| `snapshot_config`         | `lib.rs`              | Internal snapshot helper           |
+| `rollback_config`         | `lib.rs`              | Admin rollback entry point         |
+| `list_config_versions`    | `lib.rs`              | Query all versions                 |
+| `get_config_version`      | `lib.rs`              | Query single version               |
+| `compare_config_versions` | `lib.rs`              | Diff two versions                  |
+| `config_versioning_tests` | `src/config_versioning_tests.rs` | Full test suite        |
+| `upgrade_migration_tests` | `src/upgrade_migration_tests.rs` | Migration/rollback tests |

--- a/docs/VRF.md
+++ b/docs/VRF.md
@@ -1,0 +1,111 @@
+# VRF Integration
+
+Tossd uses a Verifiable Random Function (VRF) as a third independent randomness
+source, layered on top of the existing commit-reveal scheme.  The result is a
+three-party randomness protocol where **player**, **contract**, and **oracle**
+must all cooperate to predict the outcome.
+
+## How it works
+
+### Three-party randomness
+
+```
+outcome = SHA-256(player_secret || (contract_random XOR vrf_output))
+```
+
+| Contribution      | Source                                    | Committed when?         |
+|-------------------|-------------------------------------------|-------------------------|
+| `player_secret`   | Player's off-chain random value           | `start_game` (as hash)  |
+| `contract_random` | SHA-256(ledger_sequence) at game start    | `start_game`            |
+| `vrf_output`      | SHA-256(oracle_proof) at reveal time      | `reveal`                |
+
+No single party can bias the outcome:
+- The player cannot change their secret after committing.
+- The contract cannot change the ledger sequence after the game starts.
+- The oracle cannot change its proof without invalidating the Ed25519 signature.
+
+### VRF input
+
+At `start_game`, the contract computes:
+
+```
+vrf_input = SHA-256(commitment || contract_random)
+```
+
+This is the message the oracle must sign.  Because `contract_random` is already
+fixed on-chain before the oracle signs, the oracle cannot pre-compute a signature
+that biases the outcome.
+
+### VRF proof
+
+The oracle signs `vrf_input` with its Ed25519 private key.  The resulting 64-byte
+signature is the VRF proof.  The player submits this proof in the `reveal` call.
+
+### Verification
+
+In `reveal`, the contract:
+
+1. Calls `verify_vrf_proof(oracle_pk, vrf_input, vrf_proof)` — this calls
+   `env.crypto().ed25519_verify` which panics (aborting the transaction) if the
+   signature is invalid.
+2. Derives `vrf_output = SHA-256(vrf_proof)`.
+3. XORs `vrf_output` into `contract_random` to produce the aggregated randomness.
+4. Derives the outcome from `SHA-256(player_secret || aggregated)`.
+
+The VRF proof is stored in `HistoryEntry.vrf_proof` so any past game can be
+independently re-verified off-chain.
+
+## Fallback: no-oracle mode
+
+When `oracle_vrf_pk` is all-zero bytes (`[0u8; 32]`), VRF verification is
+skipped entirely.  The player submits an all-zero proof and the game proceeds
+using only the commit-reveal randomness.
+
+This is the **backward-compatible fallback** for deployments without an oracle.
+In production, always set a real Ed25519 public key.
+
+```rust
+// No-oracle deployment
+let zero_pk = BytesN::from_array(&env, &[0u8; 32]);
+client.initialize(&admin, &treasury, &token, &fee_bps, &min_wager, &max_wager, &zero_pk);
+
+// Reveal with zero proof (no oracle required)
+let zero_proof = BytesN::from_array(&env, &[0u8; 64]);
+client.reveal(&player, &secret, &zero_proof);
+```
+
+## Oracle integration
+
+### Off-chain oracle flow
+
+1. Oracle monitors `start_game` events for `vrf_input` values.
+2. Oracle signs each `vrf_input` with its Ed25519 private key.
+3. Player retrieves the signature (VRF proof) from the oracle API.
+4. Player submits `reveal(secret, vrf_proof)`.
+
+### Key management
+
+- The oracle's Ed25519 public key is stored in `ContractConfig.oracle_vrf_pk`.
+- It is set at `initialize` time and can be rotated by the admin via `update_config`.
+- The private key must be kept in a secure HSM; compromise allows the oracle to
+  bias outcomes.
+
+## Security properties
+
+| Property        | Guarantee                                                        |
+|-----------------|------------------------------------------------------------------|
+| Unpredictability | Outcome cannot be predicted before `reveal` without knowing all three secrets |
+| Verifiability   | Anyone can re-verify the oracle's contribution using the stored `vrf_proof` and the public key from `ContractConfig` |
+| Fallback safety | Zero public key disables oracle without breaking the commit-reveal guarantee |
+| Replay safety   | `vrf_input` binds the proof to a specific game via `commitment || contract_random` |
+
+## Relevant code
+
+| Symbol                  | File                        | Description                              |
+|-------------------------|-----------------------------|------------------------------------------|
+| `verify_vrf_proof`      | `contract/src/lib.rs:1418`  | Ed25519 verification with zero-pk bypass |
+| `generate_outcome`      | `contract/src/lib.rs:1608`  | Outcome derivation with VRF XOR          |
+| `ContractConfig.oracle_vrf_pk` | `contract/src/lib.rs:543` | Oracle public key storage           |
+| `GameState.vrf_input`   | `contract/src/lib.rs:500`   | Per-game VRF input (committed at start)  |
+| `HistoryEntry.vrf_proof`| `contract/src/lib.rs:617`   | Stored proof for off-chain verification  |
+| `vrf_tests.rs`          | `contract/src/vrf_tests.rs` | Unit and integration tests               |


### PR DESCRIPTION
## Summary

Implements three issues on a single branch (`feat/vrf-integration`):

### #469 — VRF integration for enhanced randomness
- `verify_vrf_proof` with Ed25519 via `env.crypto().ed25519_verify`; zero-pk bypasses oracle (commit-reveal fallback)
- `generate_outcome` XORs `SHA-256(vrf_proof)` into `contract_random` before deriving outcome
- `oracle_vrf_pk` stored in `ContractConfig`; `vrf_input` committed at `start_game`; `vrf_proof` stored in `HistoryEntry`
- Added `test_verify_vrf_proof_invalid_proof_panics` to `vrf_tests.rs`
- Added `docs/VRF.md`

### #468 — Contract upgrade and versioning system
- `ConfigVersion` struct (version_number, ledger, label, config snapshot)
- `ConfigDiffEntry` for field-level diffs; `MAX_CONFIG_HISTORY=50`, `MAX_LABEL_BYTES=64`
- `snapshot_config` appends after every admin write; `rollback_config` restores atomically + audit snapshot
- Query API: `list_config_versions`, `get_config_version`, `compare_config_versions`
- Rewrote `upgrade_migration_tests.rs` with real contract API tests
- Added `docs/UPGRADE.md`

### #467 — Fraud detection and prevention system
- Per-player sliding-window rate limiting: max 10 games / 60 ledgers (`check_rate_limit` in `start_game`)
- Anomaly detection: win streak ≥ 8 or 20+ losses with no wins (`check_anomaly` after reveal)
- `FraudFlag` struct persisted per-player; `(tossd, fraud_flag)` event emitted for off-chain monitoring
- Admin entry points: `get_fraud_flag` (public), `clear_fraud_flag` (admin-only)
- Added `fraud_detection_tests.rs` with rate limit, anomaly, and flag tests
- Added `docs/FRAUD_DETECTION.md`

## Commits
- `f962bd4` feat: integrate VRF for enhanced randomness
- `7561a57` feat: add contract upgrade and versioning system
- `b437cd6` feat: implement fraud detection and prevention system

Closes #469, closes #468, closes #467